### PR TITLE
SCHED-73: General API for mini-model population.

### DIFF
--- a/common/api/__init__.py
+++ b/common/api/__init__.py
@@ -1,0 +1,69 @@
+from abc import ABC, abstractmethod
+from typing import Mapping
+from ..minimodel import *
+
+
+class ProgramProvider(ABC):
+    """
+    The base class for all populators of the mini-model.
+
+    In all cases, this information will be provided in JSON format, which will
+    be a dict of key - entry pairs.
+
+    The values of the entries in these pairs will be int, float, or str, so we
+    leave them as generic dict.
+    """
+    @staticmethod
+    @abstractmethod
+    def parse_program(json: dict) -> Program:
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def parse_or_group(json: dict) -> OrGroup:
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def parse_and_group(json: dict) -> AndGroup:
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def parse_observation(json: dict) -> Program:
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def parse_atom(json: dict) -> Observation:
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def parse_sidereal_target(json: dict) -> SiderealTarget:
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def parse_nonsidereal_target(json: dict) -> NonsiderealTarget:
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def parse_magnitude(json: dict) -> Magnitude:
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def parse_constraints(json: dict) -> Constraints:
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def parse_timing_window(json: dict) -> TimingWindow:
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def parse_time_allocation(json: dict) -> TimeAllocation:
+        ...


### PR DESCRIPTION
The general abstract API for mini-model population, which consists simply of static abstract functions to be implemented to populate the various elements of the mini-model. The concrete implementations (there will be one for OCS, and one for GPP, and both will receive `dict`s based on JSON objects, either provided by the ODB program extractor or the GPP GraphQL queries) will need to be written.

It is possible that some logic will end up being needed here, but since the implementations are so different, we leave it as this for now.