### PR TITLE
SCHED-85: Start of test case for basic bare bones program

### DIFF
--- a/api/ocs/__init__.py
+++ b/api/ocs/__init__.py
@@ -434,7 +434,7 @@ class OcsProgramProvider(ProgramProvider):
         internal_id = data[OcsProgramProvider._ObsKeys.INTERNAL_ID]
         title = data[OcsProgramProvider._ObsKeys.TITLE]
         site = Site[data[OcsProgramProvider._ObsKeys.ID].split('-')[0]]
-        status = ObservationStatus[data[OcsProgramProvider._ObsKeys.STATUS]]
+        status = ObservationStatus[data[OcsProgramProvider._ObsKeys.STATUS].upper()]
         active = data[OcsProgramProvider._ObsKeys.PHASE2] != 'Inactive'
         priority = Priority[data[OcsProgramProvider._ObsKeys.PRIORITY].upper()]
 
@@ -661,7 +661,7 @@ class OcsProgramProvider(ProgramProvider):
         # data to the parse_and_group method.
         root_group = OcsProgramProvider.parse_and_group(data, "Root", "Root")
 
-        too_type = TooType(data[OcsProgramProvider._ProgramKeys.TOO_TYPE].upper()) if \
+        too_type = TooType[data[OcsProgramProvider._ProgramKeys.TOO_TYPE].upper()] if \
             data[OcsProgramProvider._ProgramKeys.TOO_TYPE] != 'None' else None
 
         # Propagate the ToO type down through the root group to get to the observation.

--- a/common/minimodel/__init__.py
+++ b/common/minimodel/__init__.py
@@ -4,8 +4,7 @@
 import logging
 from abc import ABC, abstractmethod
 from astropy.coordinates import EarthLocation, UnknownSiteException
-from astropy.time import Time
-from astropy import units as u
+from astropy.time import Time, TimeDelta
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import Enum, IntEnum, auto
@@ -270,40 +269,37 @@ class Constraints:
     # clearance_windows: Optional[List[ClearanceWindow]] = None
     strehl: Optional[Strehl] = None
 
-    # For performance increase to avoid repeated computation.
-    # Divide a time in milliseconds by this to get the quantity in hours.]
-    _MS_TO_H: ClassVar[int] = u.hour.to('ms') * u.hour
-
     def __post_init__(self):
         """
         Convert the timing window information to more natural units, i.e. a list of
         AstroPy Time, which is for more convenient processing.
 
         This creates a property on the Constraints called ot_timing_windows.
+
+        TODO: Do we need this?
         """
-        self.ot_timing_windows = []
+        self.ot_timing_windows: List[Time] = []
 
         # Collect the timing window information as arrays from the TimingWindow list.
-        starts = (tw.start.timestamp() for tw in self.timing_windows)
-        durations = (tw.duration.total_seconds() for tw in self.timing_windows)
+        starts = (tw.start for tw in self.timing_windows)
+        durations = (tw.duration for tw in self.timing_windows)
         repeats = (tw.repeat for tw in self.timing_windows)
         periods = (tw.period for tw in self.timing_windows)
 
-        for (start, duration, repeat, period) in zip(starts, durations, repeats, periods):
-            t0 = float(start) * u.ms
-            begin = Time(t0.to_value('s'), format='unix', scale='utc')
-            duration = TimingWindow.INFINITE_DURATION if duration == -1 else duration / Constraints._MS_TO_H
-            repeat = TimingWindow.ocs_infinite_repeats if repeat == TimingWindow.FOREVER_REPEATING else max(1, repeat)
-            period = period / Constraints._MS_TO_H
+        for (s, d, r, p) in zip(starts, durations, repeats, periods):
+            start = Time(s)
+            duration = TimeDelta.max if d == -1 else TimeDelta(d)
+            repeat = TimingWindow.ocs_infinite_repeats if r == TimingWindow.FOREVER_REPEATING else max(1, r)
+            period = None if p is None else TimeDelta(p)
 
             for i in range(repeat):
-                window_start = begin + i * period
+                window_start = start if period is None else start + i * period
                 window_end = window_start + duration
 
                 # TODO: This does not seem correct.
                 # TODO: We should be inserting TimingWindow into this list, and not these
                 # TODO: AstroPy Time objects, which are unexpected and cannot be indexed.
-                self.timing_windows.append(Time[window_start, window_end])
+                self.ot_timing_windows.append(Time([window_start, window_end]))
 
 
 class MagnitudeSystem(Enum):
@@ -367,7 +363,7 @@ class Magnitude:
     """
     band: MagnitudeBands
     value: float
-    error: Optional[float]
+    error: Optional[float] = None
 
 
 class TargetType(Enum):
@@ -516,6 +512,7 @@ class ObservationStatus(IntEnum):
     ONGOING = auto()
     OBSERVED = auto()
     INACTIVE = auto()
+    PHASE2 = auto()
 
 
 class Priority(IntEnum):
@@ -604,7 +601,7 @@ class Observation:
     # TODO: Propose we eliminate this and make it a set of Resource since
     # TODO: instruments and their configurable components will be viewed
     # TODO: as Resources.
-    instrument_configuration: InstrumentConfiguration
+    instrument_configuration: Optional[InstrumentConfiguration]
 
     setuptime_type: SetupTimeType
     acq_overhead: timedelta

--- a/data/GN-2022A-Q-999.json
+++ b/data/GN-2022A-Q-999.json
@@ -1,0 +1,898 @@
+{"PROGRAM_BASIC" : {
+  "tooType" : "Rapid",
+  "GROUP_GROUP_SCHEDULING-2" : {
+    "name" : "TestGroup",
+    "key" : "bfb1b938-fae0-45bb-b13e-a95d65d9d4f8",
+    "OBSERVATION_BASIC-0" : {
+      "SCHEDULING_CONDITIONS-0" : {
+        "elevationConstraintType" : "Airmass",
+        "timingWindows" : [],
+        "wv" : "Any",
+        "key" : "8bb9ec20-4871-402f-abf8-8c1b5461372e",
+        "sb" : "Any/Bright",
+        "elevationConstraintMin" : 1.1,
+        "elevationConstraintMax" : 2.1,
+        "cc" : "Any",
+        "iq" : "Any"
+      },
+      "priority" : "Low",
+      "setupTime" : 360000,
+      "TELESCOPE_TARGETENV-1" : {
+        "userTargets" : [],
+        "primaryIndex" : 0,
+        "base" : {
+          "name" : "M11",
+          "epoch" : 2000.0,
+          "tag" : "sidereal",
+          "deltara" : -1.568,
+          "deltadec" : -4.144,
+          "ra" : "18:51:03.840",
+          "magnitudes" : [
+            {
+              "name" : "B",
+              "value" : 6.32,
+              "system" : "Vega"
+            },
+            {
+              "name" : "V",
+              "value" : 5.8,
+              "system" : "Vega"
+            }
+          ],
+          "type" : "Base",
+          "dec" : "353:43:40.80"
+        },
+        "key" : "9aac8668-d49c-4afb-9935-54d8124680c8",
+        "guideGroups" : [
+          {
+            "name" : "auto",
+            "tag" : "auto",
+            "primaryGroup" : true,
+            "guideProbe" : [
+              {
+                "guideProbeKey" : "GMOS OIWFS",
+                "target" : {
+                  "name" : "419-102509",
+                  "epoch" : 2000.0,
+                  "tag" : "sidereal",
+                  "deltara" : -0.6,
+                  "deltadec" : -7.4,
+                  "ra" : "18:50:50.990",
+                  "magnitudes" : [
+                    {
+                      "name" : "B",
+                      "value" : 12.261,
+                      "system" : "Vega"
+                    },
+                    {
+                      "name" : "g",
+                      "value" : 12.046,
+                      "system" : "AB"
+                    },
+                    {
+                      "name" : "V",
+                      "value" : 11.983,
+                      "system" : "Vega"
+                    },
+                    {
+                      "name" : "UC",
+                      "value" : 12.0,
+                      "system" : "Vega"
+                    },
+                    {
+                      "name" : "r",
+                      "value" : 11.927,
+                      "system" : "AB"
+                    },
+                    {
+                      "name" : "i",
+                      "value" : 11.875,
+                      "system" : "AB"
+                    },
+                    {
+                      "name" : "J",
+                      "value" : 11.11,
+                      "system" : "Vega"
+                    },
+                    {
+                      "name" : "H",
+                      "value" : 11.0,
+                      "system" : "Vega"
+                    },
+                    {
+                      "name" : "K",
+                      "value" : 10.894,
+                      "system" : "Vega"
+                    }
+                  ],
+                  "type" : "GuideStar",
+                  "dec" : "353:44:28.68"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "obsLog" : [],
+      "setupTimeType" : "FULL",
+      "obsStatus" : "PHASE2",
+      "observationId" : "GN-2022A-Q-999-3",
+      "key" : "1a4f101b-de28-4ed1-959f-607b6618705c",
+      "sequence" : [
+        {
+          "ocs:obsConditions:WaterVapor" : "100",
+          "instrument:mosPreimaging" : "No",
+          "instrument:version" : "2009A-1",
+          "instrument:port" : "side-looking",
+          "instrument:gainSetting" : "2",
+          "instrument:useNS" : "false",
+          "telescope:version" : "2009B-1",
+          "instrument:fpu" : "None",
+          "ocs:obsConditions:ImageQuality" : "100",
+          "instrument:observingWavelength" : "0.475",
+          "instrument:gainChoice" : "Low",
+          "observe:object" : "M11",
+          "instrument:posAngle" : "0.0",
+          "instrument:exposureTime" : "50.0",
+          "telescope:Base:name" : "M11",
+          "telescope:guideWithPWFS1" : "park",
+          "metadata:stepcount" : "1",
+          "instrument:disperserOrder" : "1",
+          "ocs:observationId" : "GN-2022A-Q-999-3",
+          "instrument:ampReadMode" : "Slow",
+          "instrument:stageMode" : "Follow in XY",
+          "ocs:obsConditions:SkyBackground" : "100",
+          "instrument:dtaXOffset" : "0",
+          "instrument:fpuMode" : "Builtin",
+          "instrument:ampCount" : "Twelve",
+          "observe:observeType" : "OBJECT",
+          "metadata:spnodekey" : "ee164f41-6787-460a-b1ae-5bff95314a0e",
+          "instrument:disperserLambda" : "550.0",
+          "observe:dataLabel" : "GN-2022A-Q-999-3-001",
+          "ocs:obsConditions:MinAirmass" : "1.1",
+          "ocs:obsConditions:MaxAirmass" : "2.1",
+          "instrument:ccdYBinning" : "2",
+          "observe:headerVisibility" : "PUBLIC",
+          "telescope:guideWithPWFS2" : "park",
+          "instrument:adc" : "No Correction",
+          "smartgcal:maperror" : "false",
+          "observe:proprietaryMonths" : "12",
+          "instrument:ccdXBinning" : "2",
+          "instrument:builtinROI" : "Full Frame Readout",
+          "instrument:filter" : "g_G0301",
+          "observe:exposureTime" : "50.0",
+          "observe:class" : "science",
+          "observe:status" : "ready",
+          "instrument:disperser" : "Mirror",
+          "telescope:guideWithOIWFS" : "guide",
+          "observe:sciBand" : "2",
+          "ocs:obsConditions:CloudCover" : "100",
+          "totalTime" : 84300,
+          "instrument:detectorManufacturer" : "HAMAMATSU",
+          "metadata:complete" : "false",
+          "smartgcal:keyProvider" : "edu.gemini.spModel.gemini.gmos.InstGmosNorth@5ebf5314",
+          "ocs:programId" : "GN-2022A-Q-999",
+          "instrument:instrument" : "GMOS-N"
+        }
+      ],
+      "tooOverrideRapid" : false,
+      "obsClass" : "science",
+      "title" : "GMOSN-2",
+      "qaState" : "UNDEFINED",
+      "phase2Status" : "Phase 2"
+    },
+    "OBSERVATION_BASIC-1" : {
+      "SCHEDULING_CONDITIONS-0" : {
+        "elevationConstraintType" : "None",
+        "timingWindows" : [
+          {
+            "start" : 1641946051128,
+            "duration" : 86400000,
+            "period" : 0,
+            "repeat" : 0
+          }
+        ],
+        "wv" : "Any",
+        "key" : "5e940b35-db65-45e0-a2d2-9f00a31416f7",
+        "sb" : "20%/Darkest",
+        "elevationConstraintMin" : 1.0,
+        "elevationConstraintMax" : 2.0,
+        "cc" : "Any",
+        "iq" : "Any"
+      },
+      "priority" : "High",
+      "setupTime" : 900000,
+      "TELESCOPE_TARGETENV-1" : {
+        "userTargets" : [],
+        "primaryIndex" : 0,
+        "base" : {
+          "name" : "M22",
+          "epoch" : 2000.0,
+          "tag" : "sidereal",
+          "deltara" : 9.82,
+          "deltadec" : -5.54,
+          "ra" : "18:36:23.940",
+          "magnitudes" : [
+            {
+              "name" : "B",
+              "value" : 7.16,
+              "system" : "Vega"
+            },
+            {
+              "name" : "V",
+              "value" : 6.17,
+              "system" : "Vega"
+            },
+            {
+              "name" : "K",
+              "value" : 1.71,
+              "system" : "Vega"
+            }
+          ],
+          "type" : "Base",
+          "dec" : "336:05:42.90"
+        },
+        "key" : "c283964c-fd0c-4630-872d-e5f073739a31",
+        "guideGroups" : [
+          {
+            "name" : "auto",
+            "tag" : "auto",
+            "primaryGroup" : true,
+            "guideProbe" : [
+              {
+                "guideProbeKey" : "PWFS2",
+                "target" : {
+                  "name" : "331-171970",
+                  "epoch" : 2000.0,
+                  "tag" : "sidereal",
+                  "deltara" : 10.6,
+                  "deltadec" : 0.1,
+                  "ra" : "18:36:36.196",
+                  "magnitudes" : [
+                    {
+                      "name" : "B",
+                      "value" : 12.888,
+                      "system" : "Vega"
+                    },
+                    {
+                      "name" : "g",
+                      "value" : 11.93,
+                      "system" : "AB"
+                    },
+                    {
+                      "name" : "V",
+                      "value" : 11.051,
+                      "system" : "Vega"
+                    },
+                    {
+                      "name" : "UC",
+                      "value" : 10.586,
+                      "system" : "Vega"
+                    },
+                    {
+                      "name" : "r",
+                      "value" : 10.343,
+                      "system" : "AB"
+                    },
+                    {
+                      "name" : "i",
+                      "value" : 9.839,
+                      "system" : "AB"
+                    },
+                    {
+                      "name" : "J",
+                      "value" : 7.754,
+                      "system" : "Vega"
+                    },
+                    {
+                      "name" : "H",
+                      "value" : 6.993,
+                      "system" : "Vega"
+                    },
+                    {
+                      "name" : "K",
+                      "value" : 6.769,
+                      "system" : "Vega"
+                    }
+                  ],
+                  "type" : "GuideStar",
+                  "dec" : "336:00:20.55"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "obsLog" : [],
+      "setupTimeType" : "FULL",
+      "obsStatus" : "READY",
+      "observationId" : "GN-2022A-Q-999-4",
+      "key" : "aef545e2-c330-4c71-9521-c18a9cb3ee34",
+      "sequence" : [
+        {
+          "ocs:obsConditions:TimingWindowRepeat0" : "0",
+          "ocs:obsConditions:WaterVapor" : "100",
+          "instrument:version" : "2017A-1",
+          "instrument:coadds" : "1",
+          "telescope:version" : "2009B-1",
+          "ocs:obsConditions:TimingWindowPeriod0" : "0",
+          "instrument:hartmannMask" : "Out",
+          "ocs:obsConditions:ImageQuality" : "100",
+          "instrument:issPort" : "Side-looking",
+          "instrument:observingWavelength" : "2.2",
+          "observe:object" : "M22",
+          "instrument:posAngle" : "0.0",
+          "instrument:wollastonPrism" : "No",
+          "instrument:exposureTime" : "17.0",
+          "telescope:Base:name" : "M22",
+          "telescope:guideWithPWFS1" : "park",
+          "metadata:stepcount" : "1",
+          "ocs:obsConditions:TimingWindowStart0" : "1641946051128",
+          "ocs:observationId" : "GN-2022A-Q-999-4",
+          "instrument:readMode" : "Bright Objects",
+          "ocs:obsConditions:TimingWindowDuration0" : "86400000",
+          "ocs:obsConditions:SkyBackground" : "20",
+          "instrument:focus" : "best focus",
+          "observe:observeType" : "OBJECT",
+          "metadata:spnodekey" : "13ee7892-7e2f-410e-8eee-ef472a88b474",
+          "instrument:acquisitionMirror" : "out",
+          "observe:dataLabel" : "GN-2022A-Q-999-4-001",
+          "instrument:wellDepth" : "SHALLOW",
+          "observe:headerVisibility" : "PUBLIC",
+          "telescope:guideWithPWFS2" : "guide",
+          "instrument:centralWavelength" : "2.2",
+          "smartgcal:maperror" : "false",
+          "observe:proprietaryMonths" : "12",
+          "observe:coadds" : "1",
+          "observe:exposureTime" : "17.0",
+          "instrument:pixelScale" : "0.15\"/pix",
+          "observe:class" : "science",
+          "observe:status" : "ready",
+          "instrument:disperser" : "32 l/mm grating",
+          "telescope:guideWithOIWFS" : "park",
+          "observe:sciBand" : "2",
+          "ocs:obsConditions:CloudCover" : "100",
+          "instrument:camera" : "short blue",
+          "totalTime" : 26190,
+          "metadata:complete" : "false",
+          "instrument:slitWidth" : "0.30 arcsec",
+          "smartgcal:keyProvider" : "edu.gemini.spModel.gemini.gnirs.InstGNIRS@6c024a4",
+          "ocs:programId" : "GN-2022A-Q-999",
+          "instrument:crossDispersed" : "No",
+          "instrument:instrument" : "GNIRS"
+        }
+      ],
+      "tooOverrideRapid" : false,
+      "obsClass" : "science",
+      "title" : "GNIRS-2",
+      "qaState" : "PASS",
+      "phase2Status" : "Prepared"
+    }
+  },
+  "isThesis" : true,
+  "OBSERVATION_BASIC-0" : {
+    "SCHEDULING_CONDITIONS-0" : {
+      "elevationConstraintType" : "None",
+      "timingWindows" : [],
+      "wv" : "20%/Low",
+      "key" : "404ff028-e545-48c0-9392-b7de5ddbb64c",
+      "sb" : "20%/Darkest",
+      "elevationConstraintMin" : 0.0,
+      "elevationConstraintMax" : 0.0,
+      "cc" : "50%/Clear",
+      "iq" : "20%/Best"
+    },
+    "priority" : "Low",
+    "setupTime" : 900000,
+    "TELESCOPE_TARGETENV-1" : {
+      "userTargets" : [],
+      "primaryIndex" : 0,
+      "base" : {
+        "name" : "M10",
+        "epoch" : 2000.0,
+        "tag" : "sidereal",
+        "deltara" : -4.72,
+        "deltadec" : -6.54,
+        "ra" : "16:57:09.050",
+        "magnitudes" : [
+          {
+            "name" : "g",
+            "value" : 6.842,
+            "system" : "AB"
+          },
+          {
+            "name" : "V",
+            "value" : 4.98,
+            "system" : "Vega"
+          },
+          {
+            "name" : "K",
+            "value" : 3.6,
+            "system" : "Vega"
+          }
+        ],
+        "type" : "Base",
+        "dec" : "355:53:58.88"
+      },
+      "key" : "ccba87a0-63ad-4b1b-8074-c9c14d245e8e",
+      "guideGroups" : [
+        {
+          "name" : "auto",
+          "tag" : "auto",
+          "primaryGroup" : true,
+          "guideProbe" : [
+            {
+              "guideProbeKey" : "PWFS2",
+              "target" : {
+                "name" : "430-067087",
+                "epoch" : 2000.0,
+                "tag" : "sidereal",
+                "deltara" : -2.7,
+                "deltadec" : 5.7,
+                "ra" : "16:57:12.230",
+                "magnitudes" : [
+                  {
+                    "name" : "B",
+                    "value" : 12.927,
+                    "system" : "Vega"
+                  },
+                  {
+                    "name" : "g",
+                    "value" : 12.321,
+                    "system" : "AB"
+                  },
+                  {
+                    "name" : "V",
+                    "value" : 11.78,
+                    "system" : "Vega"
+                  },
+                  {
+                    "name" : "UC",
+                    "value" : 11.637,
+                    "system" : "Vega"
+                  },
+                  {
+                    "name" : "r",
+                    "value" : 11.389,
+                    "system" : "AB"
+                  },
+                  {
+                    "name" : "i",
+                    "value" : 11.04,
+                    "system" : "AB"
+                  },
+                  {
+                    "name" : "J",
+                    "value" : 9.628,
+                    "system" : "Vega"
+                  },
+                  {
+                    "name" : "H",
+                    "value" : 9.082,
+                    "system" : "Vega"
+                  },
+                  {
+                    "name" : "K",
+                    "value" : 8.916,
+                    "system" : "Vega"
+                  }
+                ],
+                "type" : "GuideStar",
+                "dec" : "355:48:33.04"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "obsLog" : [],
+    "setupTimeType" : "FULL",
+    "obsStatus" : "PHASE2",
+    "observationId" : "GN-2022A-Q-999-2",
+    "key" : "f1e411e3-ec93-430a-ac1d-1c5db3a103e6",
+    "sequence" : [
+      {
+        "ocs:obsConditions:WaterVapor" : "20",
+        "instrument:version" : "2017A-1",
+        "instrument:coadds" : "1",
+        "telescope:version" : "2009B-1",
+        "instrument:hartmannMask" : "Out",
+        "ocs:obsConditions:ImageQuality" : "20",
+        "instrument:issPort" : "Side-looking",
+        "instrument:observingWavelength" : "2.2",
+        "observe:object" : "M10",
+        "instrument:posAngle" : "0.0",
+        "instrument:wollastonPrism" : "No",
+        "instrument:exposureTime" : "17.0",
+        "telescope:Base:name" : "M10",
+        "telescope:guideWithPWFS1" : "park",
+        "metadata:stepcount" : "1",
+        "ocs:observationId" : "GN-2022A-Q-999-2",
+        "instrument:readMode" : "Bright Objects",
+        "ocs:obsConditions:SkyBackground" : "20",
+        "instrument:focus" : "best focus",
+        "observe:observeType" : "OBJECT",
+        "metadata:spnodekey" : "1b712efd-659d-4854-ae75-a2ea278f82b1",
+        "instrument:acquisitionMirror" : "out",
+        "observe:dataLabel" : "GN-2022A-Q-999-2-001",
+        "instrument:wellDepth" : "SHALLOW",
+        "observe:headerVisibility" : "PUBLIC",
+        "telescope:guideWithPWFS2" : "guide",
+        "instrument:centralWavelength" : "2.2",
+        "smartgcal:maperror" : "false",
+        "observe:proprietaryMonths" : "12",
+        "observe:coadds" : "1",
+        "observe:exposureTime" : "17.0",
+        "instrument:pixelScale" : "0.15\"/pix",
+        "observe:class" : "science",
+        "observe:status" : "ready",
+        "instrument:disperser" : "32 l/mm grating",
+        "telescope:guideWithOIWFS" : "park",
+        "observe:sciBand" : "2",
+        "ocs:obsConditions:CloudCover" : "50",
+        "instrument:camera" : "short blue",
+        "totalTime" : 26190,
+        "metadata:complete" : "false",
+        "instrument:slitWidth" : "0.30 arcsec",
+        "smartgcal:keyProvider" : "edu.gemini.spModel.gemini.gnirs.InstGNIRS@c4ef518",
+        "ocs:programId" : "GN-2022A-Q-999",
+        "instrument:crossDispersed" : "No",
+        "instrument:instrument" : "GNIRS"
+      }
+    ],
+    "tooOverrideRapid" : false,
+    "obsClass" : "science",
+    "title" : "GNIRS-1",
+    "qaState" : "UNDEFINED",
+    "phase2Status" : "Phase 2"
+  },
+  "GROUP_GROUP_FOLDER-1" : {
+    "name" : "TestFolder",
+    "key" : "01434d0e-8c2a-4364-93fb-0ccef0f32dd2",
+    "OBSERVATION_BASIC-0" : {
+      "SCHEDULING_CONDITIONS-0" : {
+        "elevationConstraintType" : "Hour Angle",
+        "timingWindows" : [
+          {
+            "start" : 1641940050498,
+            "duration" : 86400000,
+            "period" : 0,
+            "repeat" : 0
+          },
+          {
+            "start" : 1642026522000,
+            "duration" : -1,
+            "period" : 0,
+            "repeat" : 0
+          },
+          {
+            "start" : 1642112977000,
+            "duration" : 43200000,
+            "period" : 129600000,
+            "repeat" : -1
+          },
+          {
+            "start" : 1642199551000,
+            "duration" : 86400000,
+            "period" : 172800000,
+            "repeat" : 10
+          }
+        ],
+        "wv" : "Any",
+        "key" : "a1892de3-466a-47db-9495-ec83e6bf9f77",
+        "sb" : "50%/Dark",
+        "elevationConstraintMin" : -4.0,
+        "elevationConstraintMax" : 4.0,
+        "cc" : "70%/Cirrus",
+        "iq" : "20%/Best"
+      },
+      "priority" : "Low",
+      "setupTime" : 300000,
+      "TELESCOPE_TARGETENV-1" : {
+        "userTargets" : [
+          {
+            "name" : "512-132390",
+            "epoch" : 2000.0,
+            "tag" : "sidereal",
+            "deltara" : 4.9,
+            "deltadec" : 0.9,
+            "ra" : "21:29:46.873",
+            "magnitudes" : [
+              {
+                "name" : "B",
+                "value" : 16.708,
+                "system" : "Vega"
+              },
+              {
+                "name" : "g",
+                "value" : 16.335,
+                "system" : "AB"
+              },
+              {
+                "name" : "V",
+                "value" : 16.062,
+                "system" : "Vega"
+              },
+              {
+                "name" : "UC",
+                "value" : 16.017,
+                "system" : "Vega"
+              },
+              {
+                "name" : "r",
+                "value" : 15.77,
+                "system" : "AB"
+              },
+              {
+                "name" : "J",
+                "value" : 14.455,
+                "system" : "Vega"
+              },
+              {
+                "name" : "H",
+                "value" : 13.997,
+                "system" : "Vega"
+              },
+              {
+                "name" : "K",
+                "value" : 13.845,
+                "system" : "Vega"
+              }
+            ],
+            "type" : "Tuning Star",
+            "dec" : "12:12:57.61"
+          },
+          {
+            "name" : "511-136970",
+            "epoch" : 2000.0,
+            "tag" : "sidereal",
+            "deltara" : -21.0,
+            "deltadec" : -12.9,
+            "ra" : "21:29:42.967",
+            "magnitudes" : [
+              {
+                "name" : "UC",
+                "value" : 14.91,
+                "system" : "Vega"
+              },
+              {
+                "name" : "J",
+                "value" : 13.504,
+                "system" : "Vega"
+              },
+              {
+                "name" : "H",
+                "value" : 13.003,
+                "system" : "Vega"
+              },
+              {
+                "name" : "K",
+                "value" : 12.884,
+                "system" : "Vega"
+              }
+            ],
+            "type" : "Blind-offset",
+            "dec" : "12:09:53.42"
+          }
+        ],
+        "primaryIndex" : 0,
+        "base" : {
+          "name" : "M15",
+          "epoch" : 2000.0,
+          "tag" : "sidereal",
+          "deltara" : -0.63,
+          "deltadec" : -3.8,
+          "ra" : "21:29:58.330",
+          "magnitudes" : [
+            {
+              "name" : "B",
+              "value" : 3.0,
+              "system" : "Vega"
+            },
+            {
+              "name" : "g",
+              "value" : 7.101,
+              "system" : "AB"
+            },
+            {
+              "name" : "r",
+              "value" : 6.692,
+              "system" : "AB"
+            },
+            {
+              "name" : "i",
+              "value" : 6.439,
+              "system" : "AB"
+            },
+            {
+              "name" : "z",
+              "value" : 6.288,
+              "system" : "AB"
+            }
+          ],
+          "type" : "Base",
+          "dec" : "12:10:01.20"
+        },
+        "key" : "d9462dd9-d3bc-4d12-af52-fe4159a5f44c",
+        "guideGroups" : [
+          {
+            "name" : "auto",
+            "tag" : "auto",
+            "primaryGroup" : true,
+            "guideProbe" : [
+              {
+                "guideProbeKey" : "GMOS OIWFS",
+                "target" : {
+                  "name" : "512-132424",
+                  "epoch" : 2000.0,
+                  "tag" : "sidereal",
+                  "deltara" : -7.2,
+                  "deltadec" : -6.8,
+                  "ra" : "21:29:54.924",
+                  "magnitudes" : [
+                    {
+                      "name" : "B",
+                      "value" : 14.185,
+                      "system" : "Vega"
+                    },
+                    {
+                      "name" : "g",
+                      "value" : 13.473,
+                      "system" : "AB"
+                    },
+                    {
+                      "name" : "V",
+                      "value" : 12.834,
+                      "system" : "Vega"
+                    },
+                    {
+                      "name" : "UC",
+                      "value" : 12.388,
+                      "system" : "Vega"
+                    },
+                    {
+                      "name" : "r",
+                      "value" : 12.37,
+                      "system" : "AB"
+                    },
+                    {
+                      "name" : "i",
+                      "value" : 11.833,
+                      "system" : "AB"
+                    },
+                    {
+                      "name" : "J",
+                      "value" : 10.455,
+                      "system" : "Vega"
+                    },
+                    {
+                      "name" : "H",
+                      "value" : 9.796,
+                      "system" : "Vega"
+                    },
+                    {
+                      "name" : "K",
+                      "value" : 9.695,
+                      "system" : "Vega"
+                    }
+                  ],
+                  "type" : "GuideStar",
+                  "dec" : "12:13:22.47"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "obsLog" : [],
+      "setupTimeType" : "REACQUISITION",
+      "obsStatus" : "ONGOING",
+      "observationId" : "GN-2022A-Q-999-1",
+      "key" : "acc39a30-97a8-42de-98a6-5e77cc95d3ec",
+      "sequence" : [
+        {
+          "ocs:obsConditions:TimingWindowRepeat0" : "0",
+          "ocs:obsConditions:WaterVapor" : "100",
+          "ocs:obsConditions:TimingWindowPeriod3" : "172800000",
+          "ocs:obsConditions:TimingWindowDuration2" : "43200000",
+          "instrument:mosPreimaging" : "No",
+          "instrument:version" : "2009A-1",
+          "ocs:obsConditions:TimingWindowStart1" : "1642026522000",
+          "instrument:port" : "side-looking",
+          "instrument:gainSetting" : "2",
+          "instrument:useNS" : "false",
+          "ocs:obsConditions:TimingWindowStart3" : "1642199551000",
+          "telescope:version" : "2009B-1",
+          "instrument:fpu" : "None",
+          "ocs:obsConditions:TimingWindowPeriod0" : "0",
+          "ocs:obsConditions:ImageQuality" : "20",
+          "instrument:observingWavelength" : "0.475",
+          "ocs:obsConditions:TimingWindowDuration1" : "-1",
+          "instrument:gainChoice" : "Low",
+          "observe:object" : "M15",
+          "instrument:posAngle" : "0.0",
+          "instrument:exposureTime" : "300.0",
+          "telescope:Base:name" : "M15",
+          "telescope:guideWithPWFS1" : "park",
+          "metadata:stepcount" : "1",
+          "instrument:disperserOrder" : "1",
+          "ocs:obsConditions:TimingWindowStart0" : "1641940050498",
+          "ocs:observationId" : "GN-2022A-Q-999-1",
+          "instrument:ampReadMode" : "Slow",
+          "instrument:stageMode" : "Follow in XY",
+          "ocs:obsConditions:TimingWindowRepeat3" : "10",
+          "ocs:obsConditions:TimingWindowDuration0" : "86400000",
+          "ocs:obsConditions:SkyBackground" : "50",
+          "instrument:dtaXOffset" : "0",
+          "instrument:fpuMode" : "Builtin",
+          "instrument:ampCount" : "Twelve",
+          "ocs:obsConditions:TimingWindowPeriod1" : "0",
+          "observe:observeType" : "OBJECT",
+          "metadata:spnodekey" : "1480b87e-b07a-4d42-b370-201e94ac6deb",
+          "ocs:obsConditions:MaxHourAngle" : "4.0",
+          "instrument:disperserLambda" : "550.0",
+          "observe:dataLabel" : "GN-2022A-Q-999-1-001",
+          "instrument:ccdYBinning" : "1",
+          "observe:headerVisibility" : "PUBLIC",
+          "telescope:guideWithPWFS2" : "park",
+          "instrument:adc" : "No Correction",
+          "ocs:obsConditions:TimingWindowRepeat2" : "-1",
+          "smartgcal:maperror" : "false",
+          "observe:proprietaryMonths" : "12",
+          "instrument:ccdXBinning" : "1",
+          "instrument:builtinROI" : "Full Frame Readout",
+          "instrument:filter" : "g_G0301",
+          "observe:exposureTime" : "300.0",
+          "observe:class" : "science",
+          "observe:status" : "ready",
+          "instrument:disperser" : "Mirror",
+          "ocs:obsConditions:MinHourAngle" : "-4.0",
+          "telescope:guideWithOIWFS" : "guide",
+          "observe:sciBand" : "2",
+          "ocs:obsConditions:TimingWindowPeriod2" : "129600000",
+          "ocs:obsConditions:CloudCover" : "70",
+          "totalTime" : 392500,
+          "instrument:detectorManufacturer" : "HAMAMATSU",
+          "metadata:complete" : "false",
+          "smartgcal:keyProvider" : "edu.gemini.spModel.gemini.gmos.InstGmosNorth@7ae19c40",
+          "ocs:programId" : "GN-2022A-Q-999",
+          "ocs:obsConditions:TimingWindowStart2" : "1642112977000",
+          "instrument:instrument" : "GMOS-N",
+          "ocs:obsConditions:TimingWindowRepeat1" : "0",
+          "ocs:obsConditions:TimingWindowDuration3" : "86400000"
+        }
+      ],
+      "tooOverrideRapid" : true,
+      "obsClass" : "science",
+      "title" : "GMOSN-1",
+      "qaState" : "USABLE",
+      "phase2Status" : "Prepared"
+    }
+  },
+  "piEmail" : "",
+  "key" : "c396b9c9-9bdd-4eec-be83-81162090d032",
+  "programMode" : "Queue",
+  "piLastName" : "",
+  "timeAccountAllocationCategories" : [
+    {
+      "awardedProgramTime" : 7200000,
+      "usedProgramTime" : 0,
+      "usedPartnerTime" : 0,
+      "awardedPartnerTime" : 3600000,
+      "category" : "Canada"
+    },
+    {
+      "awardedProgramTime" : 14400000,
+      "usedProgramTime" : 0,
+      "usedPartnerTime" : 0,
+      "awardedPartnerTime" : 7200000,
+      "category" : "United States"
+    }
+  ],
+  "programId" : "GN-2022A-Q-999",
+  "queueBand" : "2",
+  "rolloverFlag" : false,
+  "awardedTime" : 21600000,
+  "investigators" : [],
+  "piFirstName" : ""
+}}

--- a/tests/test_ocs_api.py
+++ b/tests/test_ocs_api.py
@@ -1,0 +1,238 @@
+from common.minimodel import *
+from common.timeutils import sex2dec
+from api.ocs import OcsProgramProvider
+
+from datetime import datetime, timedelta
+import json
+import os
+
+
+def get_api_program() -> Program:
+    """
+    Load the GN-2022A-Q-999 program from the JSON file.
+    """
+    path = os.path.join('..', 'data', 'GN-2022A-Q-999.json')
+
+    with open(path, 'r') as f:
+        data = json.loads(f.read())
+        return OcsProgramProvider.parse_program(data['PROGRAM_BASIC'])
+
+
+def create_minimodel_program() -> Program:
+    """
+    Create the GN-2022A-Q-999 program and all its properties directly from the
+    mini-model.
+
+    Note that we do not have to worry about atoms as we have no obslog data.
+    """
+    # *** CREATE THE GMOSN-2 OBSERVATION ***
+    gmosn2constraints = Constraints(
+        cc=CloudCover.CCANY,
+        iq=ImageQuality.IQANY,
+        sb=SkyBackground.SBANY,
+        wv=WaterVapor.WVANY,
+        elevation_type=ElevationType.AIRMASS,
+        elevation_min=1.1,
+        elevation_max=2.1,
+        timing_windows=[],
+        strehl=None
+    )
+
+    gmosn2_target_1 = SiderealTarget(
+        name='M11',
+        magnitudes={
+            Magnitude(MagnitudeBands.B, 6.32),
+            Magnitude(MagnitudeBands.V, 5.8)
+        },
+        type=TargetType.BASE,
+        ra=sex2dec('18:51:03.840', todegree=True),
+        dec=sex2dec('353:43:40.80', todegree=True),
+        pm_ra=-1.568,
+        pm_dec=-4.144,
+        epoch=2000.0,
+    )
+
+    gmosn2_target_2 = SiderealTarget(
+        name='419-102509',
+        magnitudes={
+            Magnitude(MagnitudeBands.B, 12.261),
+            Magnitude(MagnitudeBands.g, 12.046),
+            Magnitude(MagnitudeBands.V, 11.983),
+            Magnitude(MagnitudeBands.UC, 12.0),
+            Magnitude(MagnitudeBands.r, 11.927),
+            Magnitude(MagnitudeBands.i, 11.875),
+            Magnitude(MagnitudeBands.J, 11.11),
+            Magnitude(MagnitudeBands.H, 11.0),
+            Magnitude(MagnitudeBands.K, 10.894)
+        },
+        type=TargetType.GUIDESTAR,
+        ra=sex2dec('18:50:50.990', todegree=True),
+        dec=sex2dec('353:44:28.68', todegree=True),
+        pm_ra=-0.6,
+        pm_dec=-7.4,
+        epoch=2000
+    )
+
+    gmosn2_targets = [gmosn2_target_1, gmosn2_target_2]
+    gmosn2_guiding = {
+        Resource(id='GMOS OIWFS', name='GMOS OIWFS') : gmosn2_target_2
+    }
+
+    gmosn2 = Observation(
+        id='GN-2022A-Q-999-3',
+        internal_id='1a4f101b-de28-4ed1-959f-607b6618705c',
+        order=0,
+        title='GMOSN-2',
+        site=Site.GN,
+        status=ObservationStatus.PHASE2,
+        active=True,
+        priority=Priority.LOW,
+        instrument_configuration=None,
+        setuptime_type=SetupTimeType.FULL,
+        acq_overhead=timedelta(milliseconds=360000),
+        exec_time=timedelta(),  # This is based on the atoms, which we have none.
+        obs_class=ObservationClass.SCIENCE,
+        targets=gmosn2_targets,
+        guiding=gmosn2_guiding,
+        sequence=[],
+        constraints=gmosn2constraints,
+        too_type=None
+    )
+
+    # Create the trivial AND group containing the gmosn2 observation.
+    gmosn2_group = AndGroup(
+        id=gmosn2.id,
+        group_name=gmosn2.title,
+        number_to_observe=1,
+        delay_min=timedelta.min,
+        delay_max=timedelta.max,
+        children=gmosn2,
+        group_option=AndOption.ANYORDER
+    )
+
+    # *** CREATE THE GNIRS-2 OBSERVATION ***
+    gnirs2constraints = Constraints(
+        cc=CloudCover.CCANY,
+        iq=ImageQuality.IQANY,
+        sb=SkyBackground.SB20,
+        wv=WaterVapor.WVANY,
+        elevation_type=ElevationType.NONE,
+        elevation_min=1.0,
+        elevation_max=2.0,
+        timing_windows=[
+            TimingWindow(
+                start=datetime.fromtimestamp(1641946051128),
+                duration=timedelta(milliseconds=86400000),
+                repeat=0,
+                period=None
+            )
+        ],
+        strehl=None
+    )
+
+    gnirs2_target_1 = SiderealTarget(
+        name='M22',
+        magnitudes={
+            Magnitude(MagnitudeBands.B, 7.16),
+            Magnitude(MagnitudeBands.V, 6.17),
+            Magnitude(MagnitudeBands.K, 1.71)
+        },
+        type=TargetType.BASE,
+        ra=sex2dec('18:36:23.940', todegree=True),
+        dec=sex2dec('336:05:42.90', todegree=True),
+        pm_ra=9.82,
+        pm_dec=-5.54,
+        epoch=2000.0
+    )
+
+    gnirs2_target_2 = SiderealTarget(
+        name='331-171970',
+        magnitudes={
+            Magnitude(MagnitudeBands.B, 12.888),
+            Magnitude(MagnitudeBands.g, 11.93),
+            Magnitude(MagnitudeBands.V, 11.051),
+            Magnitude(MagnitudeBands.UC, 10.586),
+            Magnitude(MagnitudeBands.r, 10.343),
+            Magnitude(MagnitudeBands.i, 9.839),
+            Magnitude(MagnitudeBands.J, 7.754),
+            Magnitude(MagnitudeBands.H, 6.993),
+            Magnitude(MagnitudeBands.K, 6.769)
+        },
+        type=TargetType.GUIDESTAR,
+        ra=sex2dec('18:36:36.196', todegree=True),
+        dec=sex2dec('336:00:20.55', todegree=True),
+        pm_ra=10.6,
+        pm_dec=0.1,
+        epoch=2000.0
+    )
+
+    gnirs2_targets = [gnirs2_target_1, gnirs2_target_2]
+    gnirs2_guiding = {
+        Resource('PWFS2', 'PWFS2') : gnirs2_target_2
+    }
+
+    gnirs2 = Observation(
+        id='GN-2022A-Q-999-4',
+        internal_id='aef545e2-c330-4c71-9521-c18a9cb3ee34',
+        order=0,
+        title='GNIRS-2',
+        site=Site.GN,
+        status=ObservationStatus.READY,
+        active=True,
+        priority=Priority.HIGH,
+        instrument_configuration=None,
+        setuptime_type=SetupTimeType.FULL,
+        acq_overhead=timedelta(milliseconds=90000),
+        exec_time=timedelta(),  # This is based on the atoms, which we have none.
+        obs_class=ObservationClass.SCIENCE,
+        targets=gnirs2_targets,
+        guiding=gnirs2_guiding,
+        sequence=[],
+        constraints=gnirs2constraints,
+        too_type=None
+    )
+
+    # Create the trivial AND group containing the gnirs2 observation.
+    gnirs2_group = AndGroup(
+        id=gnirs2.id,
+        group_name=gnirs2.title,
+        number_to_observe=1,
+        delay_min=timedelta.min,
+        delay_max=timedelta.max,
+        children=gnirs2,
+        group_option=AndOption.ANYORDER
+    )
+
+    # Create the Scheduling Group (AND group) containing the gmosn2 and gnirs2 groups.
+    sched_group = AndGroup(
+        id='2',
+        group_name='TestGroup',
+        number_to_observe=2,
+        delay_min=timedelta.min,
+        delay_max=timedelta.max,
+        children=[gmosn2_group, gnirs2_group],
+        group_option=AndOption.CONSEC_ORDERED
+    )
+
+    # Continue on, creating the gnirs1 observation and the gmosn1 observation.
+    # Put these in trivial AndGroups.
+    # Connect all the AndGroups in an AndGroup, which is the root group of the Program.
+    # Finally, create the Program and return it.
+
+    return ...
+
+
+def test_ocs_api():
+    """
+    Test the OCS API's ability to populate the mini-model.
+    This involves two steps:
+    1. Parse the JSON using the API.
+    2. Create a mini-model representation of the program directly by instantiating objects from the mini-model
+       and piecing them together. Look at the JSON to ensure that you are creating the objects in the right order
+       for things like lists when it comes to groups and targets.
+
+    Then compare using assert equality.
+    """
+    program1 = get_api_program()
+    program2 = create_minimodel_program()
+    assert program1 == program2


### PR DESCRIPTION
This PR is to serve as the base of a test case for the OCS API and the mini-model.

Right now it:
1. Adds a very basic program that tests the majority of the mini-model data structures, i.e. GN-2022A-Q-999
2. Adds the start of a test case to check that the API produces what we expect, in `test_ocs_api.py`
3. Fixes some small bugs in the API and mini-model.

What remains to be done is the rest of the implementation of `create_minimodel_program()` in `test_ocs_api.py`, which will be delegated to @stroncod 

Note that this PR requires `pytest` to be installed to run:
`pip install pytest`

Then `pytest` can be run on `test_ocs_api.py` and if it passes after the rest of the function is implemented, we have the results we expect.