### PR TITLE
SCHED-94: Readdition of InstConfig.

### DIFF
--- a/common/minimodel/__init__.py
+++ b/common/minimodel/__init__.py
@@ -662,6 +662,7 @@ class Observation:
     def wavelengths(self) -> Set[float]:
         """
         The set of wavelengths included in the sequence.
+        Wavelengths are specified in microns.
         """
         return {w for c in self.sequence for w in c.wavelength}
 

--- a/common/minimodel/__init__.py
+++ b/common/minimodel/__init__.py
@@ -663,7 +663,7 @@ class Observation:
         """
         The set of wavelengths included in the sequence.
         """
-        return {c.wavelength for c in self.sequence}
+        return {w for c in self.sequence for w in c.wavelength}
 
     def constraints(self) -> Set[Constraints]:
         """

--- a/common/minimodel/__init__.py
+++ b/common/minimodel/__init__.py
@@ -496,6 +496,21 @@ class QAState(IntEnum):
 
 
 @dataclass
+class InstConfig:
+    """
+    Atom instrument configuration.
+    All of these are Resource objects, but divided into categories for convenience.
+    Wavelengths are the exception, and must be specified in microns.
+    TODO: Is this necessary, or can we just have a Set[Resource] in Atom?
+    """
+    inst: Resource
+    fpu: Set[Resource]
+    disperser: Set[Resource]
+    filter: Set[Resource]
+    wavelength: Set[float]
+
+
+@dataclass
 class Atom:
     """
     Atom information, where an atom is the smallest schedulable set of steps
@@ -509,8 +524,11 @@ class Atom:
     observed: bool
     qa_state: QAState
     guide_state: bool
+
+    # TODO: Select between resources / wavelength or inst_config model.
     resources: Set[Resource]
     wavelength: Set[float]
+    # inst_config: InstConfig
 
 
 class ObservationStatus(IntEnum):


### PR DESCRIPTION
Readding the `InstConfig` class. We need to decide if we are storing all `Atom` resources in a single set or partitioning into an `InstConfig` class as demonstrated here.

NOTE: This PR is not YET ready for merging. If we go with this approach, we will have to add methods to some mini-model classes. This is for DISCUSSION purposes only currently.