### PR TITLE
SCHED-96: Variant implementation.

### DIFF
--- a/collector/__init__.py
+++ b/collector/__init__.py
@@ -1,6 +1,5 @@
-from astropy.coordinates import Angle, SkyCoord
+from astropy.coordinates import SkyCoord
 from astropy.time import TimeDelta
-from astropy.units.quantity import Quantity
 from astropy import units as u
 import numpy as np
 import time
@@ -521,7 +520,7 @@ class Collector(SchedulerComponent):
                     if base is not None:
                         self._calculate_target_info(obs, base)
 
-                    logging.info()
+                    logging.info(f'Processed observation {obs.id}.')
 
             except ValueError as e:
                 bad_program_count += 1
@@ -530,7 +529,8 @@ class Collector(SchedulerComponent):
         if bad_program_count:
             logging.error(f'Could not parse {bad_program_count} programs.')
 
-    def available_resources(self) -> Set[Resource]:
+    @staticmethod
+    def available_resources() -> Set[Resource]:
         """
         Return a set of available resources for the period under consideration.
         """
@@ -542,10 +542,20 @@ class Collector(SchedulerComponent):
             Resource(id='GMOSN')
         }
 
-    def get_actual_conditions(self) -> Conditions:
-        return Conditions(
-            CloudCover.CC50,
-            ImageQuality.IQ70,
-            SkyBackground.SB20,
-            WaterVapor.WVANY
-        )
+    @staticmethod
+    def get_actual_conditions_variant() -> Variant:
+        time_blocks = Time(["2021-04-24 04:30:00", "2021-04-24 08:00:00"], format='iso', scale='utc')
+        variants = {
+            Variant(
+                iq=ImageQuality.IQ70,
+                cc=CloudCover.CC50,
+                wv=WaterVapor.WVANY,
+                wind_dir=330.0 * u.deg,
+                wind_sep=40.0 * u.deg,
+                wind_spd=5.0 * u.m / u.s,
+                time_blocks=time_blocks
+            )
+        }
+
+        return next(filter(lambda v: v.iq == ImageQuality.IQ70 and v.cc == CloudCover.CC50, variants), None)
+

--- a/common/minimodel/__init__.py
+++ b/common/minimodel/__init__.py
@@ -4,7 +4,9 @@
 import logging
 from abc import ABC, abstractmethod
 from astropy.coordinates import EarthLocation, UnknownSiteException
+from astropy.coordinates.angles import Angle
 from astropy.time import Time
+from astropy.units import Quantity
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import Enum, IntEnum, auto
@@ -280,37 +282,21 @@ class Constraints:
     # clearance_windows: Optional[List[ClearanceWindow]] = None
     strehl: Optional[Strehl] = None
 
-    def __post_init__(self):
-        """
-        Convert the timing window information to more natural units, i.e. a list of
-        AstroPy Time, which is for more convenient processing.
 
-        This creates a property on the Constraints called ot_timing_windows.
-
-        TODO: Do we need this?
-        """
-        self.ot_timing_windows: List[Time] = []
-
-        # # Collect the timing window information as arrays from the TimingWindow list.
-        # starts = (tw.start for tw in self.timing_windows)
-        # durations = (tw.duration for tw in self.timing_windows)
-        # repeats = (tw.repeat for tw in self.timing_windows)
-        # periods = (tw.period for tw in self.timing_windows)
-        #
-        # for (s, d, r, p) in zip(starts, durations, repeats, periods):
-        #     start = Time(s)
-        #     duration = TimeDelta.max if d == -1 else TimeDelta(d)
-        #     repeat = TimingWindow.OCS_INFINITE_REPEATS if r == TimingWindow.FOREVER_REPEATING else max(1, r)
-        #     period = None if p is None else TimeDelta(p)
-        #
-        #     for i in range(repeat):
-        #         window_start = start if period is None else start + i * period
-        #         window_end = window_start + duration
-        #
-        #         # TODO: This does not seem correct.
-        #         # TODO: We should be inserting TimingWindow into this list, and not these
-        #         # TODO: AstroPy Time objects, which are unexpected and cannot be indexed.
-        #         self.ot_timing_windows.append(Time([window_start, window_end]))
+@dataclass
+class Variant:
+    """
+    A weather variant.
+    wind_speed should be in m / s.
+    TODO: No idea what time blocks are. Note this could be a list or a single value.
+    """
+    iq: ImageQuality
+    cc: CloudCover
+    wv: WaterVapor
+    wind_dir: Angle
+    wind_sep: Angle
+    wind_spd: Quantity
+    time_blocks: Time
 
 
 class MagnitudeSystem(Enum):


### PR DESCRIPTION
Migration of old Collector's weather variant mock fetching to simulate for the Env service and OCS historical data.

Implementation of `Variant` class in mini-model to represent weather variants.

@bryanmiller, could you shed some light on this?
There are more variants in the old Collector, but they are not formatted properly with regards to units. 
I am not sure what:
```
wdir = -1
```
is supposed to indicate. (Is it -180 degrees?)

Also, the `time_blocks` are not used at all. What are these supposed to mean? Is it the block for which a conditions variant is active?