### PR TITLE
SCHED-108: Additional Collector fields and accessors

### DIFF
--- a/common/output/__init__.py
+++ b/common/output/__init__.py
@@ -91,8 +91,7 @@ def print_collector_info(collector: Collector, samples: int = 60) -> NoReturn:
             print(f'\t{[a.to_value(u.deg) for a in night_events.sun_moon_ang[idx][::samples]]}')
             print('\n\n')
 
-    # TODO: Using a private property. This will be relocated.
-    targets = sorted((obs, target) for target, obs in Collector._target_info)
-    for obs, target in targets:
-        print(f'Observation {obs}, Target {target}')
-
+    target_info = sorted((obs_id, Collector.get_base_target(obs_id).name)
+                         for obs_id in Collector.get_observation_ids())
+    for obs_id, target_name in target_info:
+        print(f'Observation {obs_id}, Target {target_name}')

--- a/common/scheduler/__init__.py
+++ b/common/scheduler/__init__.py
@@ -1,6 +1,3 @@
-import logging
-
-
 class SchedulerComponent:
     """
     Base class for all Scheduler components involved in the pipeline.

--- a/selector/__init__.py
+++ b/selector/__init__.py
@@ -1,23 +1,23 @@
 from typing import FrozenSet
 
-from collector import Collector
 from common.minimodel import *
-from common.scheduler import SchedulerComponent
 
 
 @dataclass
-class Selector(SchedulerComponent):
+class Selector:
     """
     This is the Selector portion of the automated Scheduler.
-
     It selects the scheduling candidates that are viable for the data collected by
     the Collector.
     """
-    collector: Collector
+
+    start_time: datetime
+    time_length: timedelta
+    delta_time: timedelta = timedelta(minutes=1)
+    sites: FrozenSet[Site] = frozenset(s for s in Site)
 
     def __post_init__(self):
         """
         Initialize internal non-input data members.
         """
         ...
-

--- a/selector/__init__.py
+++ b/selector/__init__.py
@@ -1,21 +1,19 @@
 from typing import FrozenSet
 
+from collector import Collector
 from common.minimodel import *
+from common.scheduler import SchedulerComponent
 
 
 @dataclass
-class Selector:
+class Selector(SchedulerComponent):
     """
     This is the Selector portion of the automated Scheduler.
 
     It selects the scheduling candidates that are viable for the data collected by
     the Collector.
     """
-
-    start_time: datetime
-    time_length: timedelta
-    delta_time: timedelta = timedelta(minutes=1)
-    sites: FrozenSet[Site] = frozenset(s for s in Site)
+    collector: Collector
 
     def __post_init__(self):
         """


### PR DESCRIPTION
This is a small PR to add some more information to the `Collector` to facilitate retrieval, largely concerning observation IDs and observations.

Also added are accessors to the private data in the `Collector` so that we no longer have to unpythonically violate the private nature of fields to get its contents and calculated output.

For some reason, some harmless Scheduler crap ended up in here. Ignoring it.