### PR TITLE
SCHED-126: Interface simplification.

### DIFF
--- a/common/minimodel/__init__.py
+++ b/common/minimodel/__init__.py
@@ -696,6 +696,12 @@ class Observation:
 
     too_type: Optional[TooType] = None
 
+    def base_target(self) -> Optional[Target]:
+        """
+        Get the base target for this Observation if it has one, and None otherwise.
+        """
+        return next(filter(lambda t: t.type == TargetType.BASE, self.targets), None)
+
     def exec_time(self) -> timedelta:
         """
         Total execution time for the program, which is sum across atoms and the acquisition overhead.

--- a/components/collector/__init__.py
+++ b/components/collector/__init__.py
@@ -293,16 +293,16 @@ class Collector(SchedulerComponent):
         return Collector._programs.get(program_id, None)
 
     @staticmethod
-    def get_observation_ids(prog_id: Optional[ProgramID] = None) -> Optional[Iterable[ObservationID]]:
+    def get_observation_ids(program_id: Optional[ProgramID] = None) -> Optional[Iterable[ObservationID]]:
         """
         Return the observation IDs in the Collector.
         If the prog_id is specified, limit these to those in the specified in the program.
         If no such prog_id exists, return None.
         If no prog_id is specified, return a complete list of observation IDs.
         """
-        if prog_id is None:
+        if program_id is None:
             return Collector._observations.keys()
-        return Collector._observations_per_program.get(prog_id, None)
+        return Collector._observations_per_program.get(program_id, None)
 
     @staticmethod
     def get_observation(obs_id: ObservationID) -> Optional[Observation]:
@@ -579,7 +579,7 @@ class Collector(SchedulerComponent):
 
                 for obs in tqdm(good_obs, leave=False):
                     # Retrieve tne base target, if any. If not, we cannot process.
-                    base = next(filter(lambda t: t.type == TargetType.BASE, obs.targets), None)
+                    base = obs.base_target()
 
                     # Record the observation and target for this observation ID.
                     Collector._observations[obs.id] = obs, base

--- a/components/selector/__init__.py
+++ b/components/selector/__init__.py
@@ -6,7 +6,7 @@ import astropy.units as u
 from api.observatory.abstract import ObservatoryProperties
 from common.minimodel import *
 from components.base import SchedulerComponent
-from components.collector import Collector, NightIndex
+from components.collector import Collector, NightEvents, NightIndex, TargetInfoNightIndexMap
 from components.ranker import Ranker, Scores
 
 from typing import Dict, Iterable, FrozenSet, NoReturn, Set
@@ -497,3 +497,39 @@ class Selector(SchedulerComponent):
         if scalar_input:
             cmatch = np.squeeze(cmatch)
         return cmatch
+
+    def get_program_ids(self) -> Iterable[ProgramID]:
+        """
+        Simplified interface to the Collector.
+        """
+        return self.collector.get_program_ids()
+
+    def get_program(self, program_id: ProgramID) -> Optional[Program]:
+        """
+        Simplified interface to the Collector.
+        """
+        return self.collector.get_program(program_id)
+
+    def get_observation_ids(self, program_id: Optional[ProgramID] = None) -> Iterable[ObservationID]:
+        """
+        Simplified interface to the Collector.
+        """
+        return self.collector.get_observation_ids(program_id)
+
+    def get_observation(self, obs_id: ObservationID) -> Optional[Observation]:
+        """
+        Simplified interface to the Collector.
+        """
+        return self.collector.get_observation(obs_id)
+
+    def get_night_events(self, site: Site) -> Optional[NightEvents]:
+        """
+        Simplified interface to the Collector.
+        """
+        return self.collector.get_night_events(site)
+
+    def get_target_info(self, obs_id: ObservationID) -> Optional[TargetInfoNightIndexMap]:
+        """
+        Simplified interface to the Collector.
+        """
+        return self.collector.get_target_info(obs_id)

--- a/scripts/run_scheduler.py
+++ b/scripts/run_scheduler.py
@@ -42,37 +42,47 @@ if __name__ == '__main__':
     # Notes for data access:
     #
     # *** PROGRAMS ***
-    # 1. Programs are stored in the Collector. All the Program IDs in the Collector can be accessed with:
-    #       Collector.get_program_ids()
+    # 1. Programs are stored in the Collector but can be accessed more easily through the Selector.
+    #    All the Program IDs in the Collector can be accessed with:
+    #       selector.get_program_ids()
     #    which returns an iterable of program IDs.
     # 2. To get a specific program:
-    #       Collector.get_program(program_id)
-    #    which returns the mini-model representation of the Program.
+    #       selector.get_program(program_id)
+    #    which returns the mini-model representation of the Program (or None if the ID does not exist).
     #
     # *** OBSERVATIONS ***
-    # 1. To get a list of the Observation IDs:
-    #        Collector.get_observation_ids(optional prog_id, None is default)
+    # 1. Again these are stored in the Collector but to simplify, everything can be obtained through the
+    #    Selector. To get a list of the Observation IDs:
+    #        selector.get_observation_ids(optional prog_id, None is default)
     #    If there is a program ID supplied, only the observation IDs in that program are returned.
-    #    If nothing is supplied (equivalent to None being supplied), all observation IDs are returned.
+    #    If nothing is supplied (equivalent to None being supplied), all observation IDs from all programs are returned.
     # 2. To get a specific Observation:
-    #        Collector.get_observation(observation_id)
-    #    which returns the mini-model representation of the Observation.
+    #        selector.get_observation(observation_id)
+    #    which returns the mini-model representation of the Observation (or None if the ID does not exist).
     #
     # *** TARGETS ***
-    # The Collector stores target calculations in objects of the TargetInfo class. There is one TargetInfo for each
-    # target for each night.
-    # 1. To get the base target of an Observation, you can go through the mini-model or more easily:
-    #        Collector.get_base_target(observation_id)
+    # The Collector stores target calculations for an Observation's target in objects of the TargetInfo class, but this
+    # information is made available through the Selector for ease.
+    # There is one TargetInfo for each target for each night. See the TARGETINFO section below to see what this
+    # contains.
+    #
+    # 1. To get the base target of an Observation, you can go through the Observation or the Selector.
+    #    These two are equivalent:
+    #        observation.base_target()
+    #        selector.get_base_target(observation_id)
+    # If there is no base target associated with the Observation (e.g. ToOs), None is returned.
+    #
     # 2. To get the TargetInfo associated with an Observation's base target:
-    #        Collector.get_target_info(observation_id)
+    #        selector.get_target_info(observation_id)
     #    If there is no target associated with the Observation, None is returned.
     #    Otherwise, a map is returned from the NightIndex in the period (0 for the first night, 1 for the second, etc,
     #    and we could just change this to a List, I suppose) to the TargetInfo for that night for that target.
     #
     # *** NIGHTEVENTS ***
-    # The NightEvents class are the calculations for a given site. They include the values across all nights and
-    # can be retrieved with:
-    #     Collector.get_night_events(Site.GN or Site.GS)
+    # I don't know if this will be needed, but the NightEvents calculations can be obtained.
+    # The NightEvents are the calculations for a given site across all nights. They are stored in the Collector but
+    # to simplify, can be obtained from the Selector.
+    #     selector.get_night_events(Site.GN or Site.GS)
     # This may have to be modified in the future to accept date ranges, since now they return everything the Collector
     # was initialized with in terms of period length and time granularity.
     # The NightEvents class is described in the component/Collector/__init__.py file at L19.
@@ -116,16 +126,17 @@ if __name__ == '__main__':
     #      rem_visibility_frac: float, remaining observation time / rem_visibility_time
     #
     # *** GROUPS ***
-    # This is handled in the Selector. Groups can be accessed either through the mini-model Program obtained via
-    # the Collector as described above in PROGRAMS, or via these Selector methods:
-    # 1. selector_instance.get_group_ids(): returns a list of all group IDs
-    # 2. selector_instance.get_group(group_id): gets specific group by ID
+    # This is handled entirely in the Selector. Groups can be accessed either through the mini-model Program obtained
+    # as described above in the PROGRAMS section, or via these Selector methods:
+    # 1. selector.get_group_ids(): returns a list of all group IDs
+    # 2. selector.get_group(group_id): gets specific group by ID
     #
     # *** GROUPINFO ***
     # This is calculated by the Selector for each AND group.
     # If an AND group contains an OR group, at this point, it throws a NotImplementedError.
     # Obtain by using:
-    # 1. selector_instance.get_group_info(group_id): returns a map from night index to GroupInfo
+    #     selector.get_group_info(group_id): returns a map from night index to GroupInfo
+    # As with TargetInfo, we could use a List instead of a Mapping (and the interface will not change).
     #
     # The GroupInfo object for a Group contains the information for the given Group.
     #       minimum_conditions: Conditions object representing the minimum required conditions by group and all


### PR DESCRIPTION
Make everything available through the `Selector` so that we don't have to get certain things from the `Collector` and the `Selector`. The previous `Collector` methods are now accessed through the `Selector` and the base target information retrieval has been moved to the mini-model for simplicity so you can get an `Observation`'s base `Target` directly from the `Observation` instead of going through the `Collector`.