### PR TITLE
SCHED-144: Bugfixes

### DIFF
--- a/api/programprovider/ocs/__init__.py
+++ b/api/programprovider/ocs/__init__.py
@@ -631,9 +631,13 @@ class OcsProgramProvider(ProgramProvider):
             # Instrument configuration aka Resource
             # instrument = step[OcsProgramProvider._AtomKeys.INSTRUMENT]
             fpu, disperser, filt, wavelength = OcsProgramProvider._parse_instrument_configuration(step, instrument)
-            fpus.append(fpu)
+
+            # We don't want to allow FPU to be None or FPU_NONE, which are effectively the same thing.
+            if fpu != 'None' and fpu != 'FPU_NONE':
+                fpus.append(fpu)
             dispersers.append(disperser)
-            filters.append(filt)
+            if filt and filt != 'None':
+                filters.append(filt)
             wavelengths.append(wavelength)
             mode = determine_mode(instrument)
 

--- a/common/minimodel/resource.py
+++ b/common/minimodel/resource.py
@@ -13,5 +13,12 @@ class Resource:
     id: str
     description: Optional[str] = None
 
+    def __post_init__(self):
+        if self.id is None or 'NONE' in self.id.upper():
+            raise ValueError('Should not have any Resources equal to None or containing "None"')
+
     def __eq__(self, other):
         return isinstance(other, Resource) and self.id == other.id
+
+    def __repr__(self):
+        return f'Resource(id=\'{self.id}\')'

--- a/components/collector/__init__.py
+++ b/components/collector/__init__.py
@@ -438,18 +438,45 @@ class Collector(SchedulerComponent):
         site_independent_resources = {
             Resource(id='PWFS1'),
             Resource(id='PWFS2'),
-            Resource(id='GMOS OIWFS')
+            Resource(id='GMOS OIWFS'),
+            Resource(id='FII OIWFS'),
+
+            Resource(id='Mirror'),
+            Resource(id='Longslit 0.50 arcsec'),
+            Resource(id='Longslit 0.75 arcsec'),
+            Resource(id='Longslit 1.00 arcsec'),
+            Resource(id='Longslit 1.50 arcsec'),
+            Resource(id='IFU Right Slit (red)'),
         }
 
         if site == Site.GN:
             return frozenset(site_independent_resources.union({
                 Resource(id='GMOS-N'),
-                Resource(id='GNIRS')
+                Resource(id='R831_G5302'),
+                Resource(id='r_G0303'),
+                Resource(id='i_G0302'),
+                Resource(id='g_G0301'),
+
+                Resource(id='GNIRS'),
+                Resource(id='1.0 arcsec'),
+                Resource(id='32 l/mm SXD')
             }))
         elif site == Site.GS:
             return frozenset(site_independent_resources.union({
                 Resource(id='GMOS-S'),
-                Resource(id='Flamingos2')
+                Resource(id='B600_G5323'),
+                Resource(id='B1200_G5321'),
+                Resource(id='R400_G5325'),
+                Resource(id='OG515_G0330'),
+                Resource(id='r_G0326'),
+                Resource(id='i_G0327'),
+                Resource(id='g_G0325'),
+
+                Resource(id='Flamingos2'),
+                Resource(id='IMAGING'),
+                Resource(id='K_SHORT'),
+                Resource(id='H'),
+                Resource(id='J')
             }))
 
     def get_actual_conditions_variant(self,

--- a/components/selector/__init__.py
+++ b/components/selector/__init__.py
@@ -227,10 +227,8 @@ class Selector(SchedulerComponent):
         for night_idx in ranker.night_indices:
             vis_idx = target_info[night_idx].visibility_slot_idx
             if res_night_availability[night_idx]:
-                # Resources are available on night_idx, so check where the conditions_score is nonzero.
-                schedulable_slot_indices.append(np.where(conditions_score[vis_idx] > 0)[0])
+                schedulable_slot_indices.append(np.where(conditions_score[night_idx][vis_idx] > 0)[0])
             else:
-                # Resources are not available on night_idx, so no need to check conditions_score.
                 schedulable_slot_indices.append(np.array([]))
 
         # Calculate the scores for the observation across all nights across all timeslots.
@@ -238,6 +236,8 @@ class Selector(SchedulerComponent):
         # Note that np.multiply will handle lists of numpy arrays.
         # TODO: This generates a warning about ragged arrays, but seems to produce the right shape of structure.
         scores = np.multiply(np.multiply(conditions_score, ranker.get_observation_scores(obs.id)), wind_score)
+        # print(f'Scores for group: {group.id}:')
+        # print(scores)
 
         group_info = GroupInfo(
             minimum_conditions=mrc,

--- a/components/selector/__init__.py
+++ b/components/selector/__init__.py
@@ -234,10 +234,8 @@ class Selector(SchedulerComponent):
         # Calculate the scores for the observation across all nights across all timeslots.
         # Multiply by the conditions score to adjust the scores.
         # Note that np.multiply will handle lists of numpy arrays.
-        # TODO: This generates a warning about ragged arrays, but seems to produce the right shape of structure.
+        # This generates a warning about ragged array deprecation, but seems to produce the right shape of structure.
         scores = np.multiply(np.multiply(conditions_score, ranker.get_observation_scores(obs.id)), wind_score)
-        # print(f'Scores for group: {group.id}:')
-        # print(scores)
 
         group_info = GroupInfo(
             minimum_conditions=mrc,

--- a/scripts/run_scheduler.py
+++ b/scripts/run_scheduler.py
@@ -40,7 +40,6 @@ if __name__ == '__main__':
     # Execute the Selector.
     # Not sure the best way to display the output.
     selection = selector.select()
-    pass
 
     # Notes for data access:
     # The Selector returns all the data that an Optimizer needs in order to generate plans.

--- a/scripts/run_scheduler.py
+++ b/scripts/run_scheduler.py
@@ -40,6 +40,7 @@ if __name__ == '__main__':
     # Execute the Selector.
     # Not sure the best way to display the output.
     selection = selector.select()
+    pass
 
     # Notes for data access:
     # The Selector returns all the data that an Optimizer needs in order to generate plans.


### PR DESCRIPTION
1. Made `Resource` not accept `id` of `None` or equivalent of `None`.
2. Fixed `Atom` parsing code to not return FPUs and filters that are the equivalent of `None`.
3. `Collector` now makes sure `Resource` needs are all met.
4. `schedulable_slot_indices` now takes `night_idx` properly into account.