### PR TITLE
SCHED-147: Fixed issue where fpu had a value of None due to missing key in sequence.

### DIFF
--- a/api/programprovider/ocs/__init__.py
+++ b/api/programprovider/ocs/__init__.py
@@ -501,8 +501,9 @@ class OcsProgramProvider(ProgramProvider):
                 if OcsProgramProvider.FPU_FOR_INSTRUMENT[instrument] in data:
                     fpu = data[OcsProgramProvider.FPU_FOR_INSTRUMENT[instrument]]
                 else:
-                    fpu = None
                     # TODO: Might need to raise an exception here. Check code with science.
+                    # TODO: An example of where this happens is for GN-2018B-Q-103-19.
+                    fpu = None
             else:
                 raise ValueError(f'Instrument {instrument} not supported')
 
@@ -632,8 +633,9 @@ class OcsProgramProvider(ProgramProvider):
             # instrument = step[OcsProgramProvider._AtomKeys.INSTRUMENT]
             fpu, disperser, filt, wavelength = OcsProgramProvider._parse_instrument_configuration(step, instrument)
 
-            # We don't want to allow FPU to be None or FPU_NONE, which are effectively the same thing.
-            if fpu != 'None' and fpu != 'FPU_NONE':
+            # We don't want to allow FPU to be None, 'None', or FPU_NONE, which are effectively the same thing.
+            # TODO: if fpu is None, this might be an error. Check with science.
+            if fpu is not None and fpu != 'None' and fpu != 'FPU_NONE':
                 fpus.append(fpu)
             dispersers.append(disperser)
             if filt and filt != 'None':


### PR DESCRIPTION
This might be an error that we should check with in science.
In this case, the observation is GN-2018B-Q-103-19 and the failure is in `OcsProgramProvider._parse_instrument_configuration` here (L506):
```
            if instrument in OcsProgramProvider.FPU_FOR_INSTRUMENT:
                if OcsProgramProvider.FPU_FOR_INSTRUMENT[instrument] in data:
                    fpu = data[OcsProgramProvider.FPU_FOR_INSTRUMENT[instrument]]
                else:
                    # TODO: Might need to raise an exception here. Check code with science.
                    # TODO: An example of where this happens is for GN-2018B-Q-103-19.
                    fpu = None
```

It seems the key `instrument:fpu` is missing from the sequence data. I'm not sure if this is an error or not. Why would the key be missing instead of using `None` or `FPU_NONE`?