### PR TITLE
HOTFIX: Fixing time information, type hints, calculations, and cleaning output

### DIFF
--- a/api/programprovider/ocs/__init__.py
+++ b/api/programprovider/ocs/__init__.py
@@ -633,7 +633,7 @@ class OcsProgramProvider(ProgramProvider):
             fpu, disperser, filt, wavelength = OcsProgramProvider._parse_instrument_configuration(step, instrument)
 
             # We don't want to allow FPU to be None or FPU_NONE, which are effectively the same thing.
-            if fpu != 'None' and fpu != 'FPU_NONE':
+            if fpu is not None and fpu != 'None' and fpu != 'FPU_NONE':
                 fpus.append(fpu)
             dispersers.append(disperser)
             if filt and filt != 'None':
@@ -649,14 +649,14 @@ class OcsProgramProvider(ProgramProvider):
             if atom_id == 0 or (atom_id > 0 and wavelengths[atom_id] != wavelengths[prev]):
                 next_atom = True
                 # TODO: Can we make this informative?
-                logging.info('Atom for wavelength')
+                # logging.info('Atom for wavelength')
 
             if step[OcsProgramProvider._AtomKeys.OBSERVE_TYPE].upper() not in OcsProgramProvider.OBSERVE_TYPES:
                 if observe_class.upper() == 'SCIENCE' and (atom_id > 0 and
                                                            exposure_times[atom_id] != exposure_times[prev] or
                                                            coadds[atom_id] != coadds[prev]):
                     next_atom = True
-                    logging.info('Atom for exposure time change')
+                    # logging.info('Atom for exposure time change')
 
                 # Offsets - a new offset pattern is a new atom
                 if offset_lag == 0 and not exptime_groups:
@@ -670,12 +670,12 @@ class OcsProgramProvider(ProgramProvider):
                                 n_offsets += 1
                         if n_offsets % 2 == 1:
                             next_atom = True
-                            logging.info('Atom for offset pattern')
+                            # logging.info('Atom for offset pattern')
                     else:
                         n_pattern -= 1
                         if n_pattern < 0:
                             next_atom = True
-                            logging.info('Atom for offset pattern')
+                            # logging.info('Atom for offset pattern')
                             n_pattern = offset_lag - 1
                 prev = atom_id
 

--- a/common/calculations/nightevents.py
+++ b/common/calculations/nightevents.py
@@ -39,7 +39,8 @@ class NightEvents:
 
     def __post_init__(self):
         # Calculate the length of each night at this site, i.e. time between twilights.
-        night_length = (self.twilight_morning_12 - self.twilight_evening_12).to_value('h') * u.h
+        night_length = TimeDelta((self.twilight_morning_12 - self.twilight_evening_12).to(u.hour))
+        # night_length = TimeDelta((self.twilight_morning_12 - self.twilight_evening_12).to_value('hr'))
         object.__setattr__(self, 'night_length', night_length)
 
         # Create the time arrays, which are arrays that represent the earliest starting

--- a/common/minimodel/constraints.py
+++ b/common/minimodel/constraints.py
@@ -7,6 +7,7 @@ import numpy.typing as npt
 from astropy.coordinates import Angle
 from astropy.units import Quantity
 
+from common.types import ScalarOrNDArray
 from common.helpers import flatten
 from .timingwindow import TimingWindow
 
@@ -86,10 +87,10 @@ class Conditions:
     This should be done via:
     current_conditions <= required_conditions.
     """
-    cc: Union[npt.NDArray[CloudCover], CloudCover]
-    iq: Union[npt.NDArray[ImageQuality], ImageQuality]
-    sb: Union[npt.NDArray[SkyBackground], SkyBackground]
-    wv: Union[npt.NDArray[WaterVapor], WaterVapor]
+    cc: ScalarOrNDArray[CloudCover]
+    iq: ScalarOrNDArray[ImageQuality]
+    sb: ScalarOrNDArray[SkyBackground]
+    wv: ScalarOrNDArray[WaterVapor]
 
     # Least restrictive conditions.
     @classmethod

--- a/common/minimodel/plan.py
+++ b/common/minimodel/plan.py
@@ -23,8 +23,8 @@ class Plan:
         self.visits = []
         self.is_full = False
     
-    def time2slots(self, time: datetime) -> int:
-        return ceil((time.total_seconds() / 60) / self.time_slot_length.value)
+    def time2slots(self, time: timedelta) -> int:
+        return ceil((time.total_seconds() / self.time_slot_length.total_seconds()) / 60)
 
     def add(self, obs: Observation, start: datetime, time_slots: int) -> NoReturn:
         visit = Visit(start, obs.id, obs.sequence[0].id, obs.sequence[-1].id)
@@ -50,7 +50,7 @@ class Plans:
             if ne is not None:
                 self.plans[site] = Plan(ne.local_times[night_idx][0],
                                         ne.local_times[night_idx][-1],
-                                        ne.time_slot_length,
+                                        ne.time_slot_length.to_datetime(),
                                         site,
                                         len(ne.times[night_idx]))
     

--- a/common/output/__init__.py
+++ b/common/output/__init__.py
@@ -60,7 +60,7 @@ def print_collector_info(collector: Collector, samples: int = 60) -> NoReturn:
     print(f'Pre-Collector / Collector running from:')
     print(f'   start time:       {collector.start_time}')
     print(f'   end time:         {collector.end_time}')
-    print(f'   time slot length: {collector.time_slot_length}')
+    print(f'   time slot length: {collector.time_slot_length.to(u.min)}')
 
     # Print out sampled calculation for every hour as there are far too many results to print in full.
     samples = 60

--- a/common/sky/events.py
+++ b/common/sky/events.py
@@ -7,19 +7,20 @@ from astropy.coordinates import Angle, EarthLocation
 from astropy.time import Time
 from pytz import timezone
 
+from common.types import TimeScalarOrNDArray
 from common.sky.constants import EQUAT_RAD
 from common.sky.moon import Moon
 from common.sky.sun import Sun
 from common.sky.utils import local_midnight_time
 
 
-def night_events(time: Time, location: EarthLocation, localtzone: timezone) -> \
-        Tuple[Time, Union[npt.NDArray[float], Time],
-              Union[npt.NDArray[float], Time],
-              Union[npt.NDArray[float], Time],
-              Union[npt.NDArray[float], Time],
-              Union[npt.NDArray[float], Time],
-              Union[npt.NDArray[float], Time]]:
+def night_events(time: Time, location: EarthLocation, localtzone: timezone) -> Tuple[Time,
+                                                                                     TimeScalarOrNDArray,
+                                                                                     TimeScalarOrNDArray,
+                                                                                     TimeScalarOrNDArray,
+                                                                                     TimeScalarOrNDArray,
+                                                                                     TimeScalarOrNDArray,
+                                                                                     TimeScalarOrNDArray]:
     """
     Compute phenomena for a given night.
 

--- a/common/sky/events.py
+++ b/common/sky/events.py
@@ -48,11 +48,7 @@ def night_events(time: Time, location: EarthLocation, localtzone: timezone) -> \
     rise_alt = Angle(horiz * np.ones(nt), unit=u.deg)  # zd = 90 deg 50 arcmin
 
     # Sun
-    sunrise, sunset, even_12twi, morn_12twi = Sun.rise_and_set(location,
-                                                               time,
-                                                               midnight,
-                                                               set_alt,
-                                                               rise_alt)
+    sunrise, sunset, even_12twi, morn_12twi = Sun.rise_and_set(location, time, midnight, set_alt, rise_alt)
 
     # Moon
     moonrise, moonset = Moon().rise_and_set(location, midnight, set_alt, rise_alt)

--- a/common/sky/events.py
+++ b/common/sky/events.py
@@ -14,9 +14,12 @@ from common.sky.utils import local_midnight_time
 
 
 def night_events(time: Time, location: EarthLocation, localtzone: timezone) -> \
-        Tuple[Time, Union[npt.NDArray[float], Time], Union[npt.NDArray[float], Time], Union[npt.NDArray[float], Time],
-              Union[npt.NDArray[float], Time], Union[npt.NDArray[float], Time],
-              Union[npt.NDArray[float], Tuple[Angle, Time, EarthLocation]]]:
+        Tuple[Time, Union[npt.NDArray[float], Time],
+              Union[npt.NDArray[float], Time],
+              Union[npt.NDArray[float], Time],
+              Union[npt.NDArray[float], Time],
+              Union[npt.NDArray[float], Time],
+              Union[npt.NDArray[float], Time]]:
     """
     Compute phenomena for a given night.
 

--- a/common/sky/moon.py
+++ b/common/sky/moon.py
@@ -447,7 +447,7 @@ class Moon:
 
         timedelta_moon_set = TimeDelta(diff_moon_set.hour / 24., format='jd')
         times_moon_set = midnight + timedelta_moon_set
-        times_moon_set = (set_alt, times_moon_set, location)
+        times_moon_set = Moon.time_by_altitude(set_alt, times_moon_set, location)
 
         ha_moonrise = -1. * hour_angle_to_angle(moon_at_midnight.dec, location.lat, rise_alt)
         diff_moonrise = ha_moonrise - ha_moon_at_midnight  # how far from riseting point at midnight
@@ -460,8 +460,8 @@ class Moon:
         if len(jj) != 0:
             diff_moonrise[jj] = diff_moonrise[jj] + Angle(24. * u.hour)
 
-        timedelta_moonrise = TimeDelta(diff_moonrise.hour / 24., format='jd')
-        times_moonrise = midnight + timedelta_moonrise
-        times_moonrise = Moon.time_by_altitude(rise_alt, times_moonrise, location)
+        timedelta_moon_rise = TimeDelta(diff_moonrise.hour / 24., format='jd')
+        times_moon_rise = midnight + timedelta_moon_rise
+        times_moon_rise = Moon.time_by_altitude(rise_alt, times_moon_rise, location)
 
-        return times_moonrise, times_moon_set
+        return times_moon_rise, times_moon_set

--- a/common/sky/moon.py
+++ b/common/sky/moon.py
@@ -424,7 +424,7 @@ class Moon:
                      location: EarthLocation,
                      midnight: Time,
                      set_alt: Angle,
-                     rise_alt: Angle) -> Tuple[Time, Tuple[Angle, Time, EarthLocation]]:
+                     rise_alt: Angle) -> Tuple[Time, Time]:
         """
         Return times of moon rise and set.
         """

--- a/common/sky/test/test_events.py
+++ b/common/sky/test/test_events.py
@@ -19,5 +19,5 @@ def test_night_events(midnight, location):
     nptest.assert_almost_equal(even_12twi.jd, Time('2020-07-01 05:58:33.537').jd, decimal=2)
     nptest.assert_almost_equal(morn_12twi.jd, Time('2020-07-01 14:53:11.218').jd, decimal=2)
     nptest.assert_almost_equal(moonrise.jd, Time('2020-07-01 00:50:37.391').jd, decimal=2)
-    nptest.assert_almost_equal(moonset[1].jd, Time('2020-07-01 12:51:54.812').jd, decimal=2)
+    nptest.assert_almost_equal(moonset.jd, Time('2020-07-01 12:51:54.812').jd, decimal=2)
  

--- a/common/types/__init__.py
+++ b/common/types/__init__.py
@@ -1,0 +1,11 @@
+# Basic type aliases for usefulness.
+from typing import List, TypeVar, Union
+import numpy.typing as npt
+from astropy.time import Time
+
+T = TypeVar('T')
+
+
+ScalarOrNDArray = Union[T, npt.NDArray[T]]
+TimeScalarOrNDArray = Union[Time, npt.NDArray[float]]
+ListOrNDArray = Union[List[T], npt.NDArray[T]]

--- a/components/collector/__init__.py
+++ b/components/collector/__init__.py
@@ -4,7 +4,6 @@ from typing import FrozenSet, Iterable, NoReturn, Optional
 
 from astropy.units import Quantity
 from more_itertools import partition
-from tqdm import tqdm
 
 from api.programprovider.abstract import ProgramProvider
 from common.calculations import *
@@ -367,7 +366,7 @@ class Collector(SchedulerComponent):
         # Count the number of parse failures.
         bad_program_count = 0
 
-        for json_program in tqdm(data):
+        for json_program in data:
             try:
                 if len(json_program.keys()) != 1:
                     msg = f'JSON programs should only have one top-level key: {" ".join(json_program.keys())}'
@@ -400,7 +399,7 @@ class Collector(SchedulerComponent):
                 # Set the observation IDs for this program.
                 Collector._observations_per_program[program.id] = {obs.id for obs in good_obs}
 
-                for obs in tqdm(good_obs, leave=False):
+                for obs in good_obs:
                     # Retrieve tne base target, if any. If not, we cannot process.
                     base = obs.base_target()
 

--- a/components/ranker/__init__.py
+++ b/components/ranker/__init__.py
@@ -1,12 +1,11 @@
-import astropy.units as u
 from copy import deepcopy
-from dataclasses import dataclass
-import numpy as np
-import numpy.typing as npt
-from typing import Callable, Dict, FrozenSet, List, Mapping, Tuple, Union
+from typing import Callable, Dict, Tuple
 
-from common.minimodel import *
+import astropy.units as u
+
 from common.calculations import Scores
+from common.minimodel import *
+from common.types import ListOrNDArray
 from components.collector import Collector
 
 
@@ -115,7 +114,7 @@ class Ranker:
                 self._observation_scores[obs.id] = self._score_obs(program, obs)
 
     def _metric_slope(self,
-                      completion: Union[List[float], npt.NDArray[float]],
+                      completion: ListOrNDArray[float],
                       band: npt.NDArray[Band],
                       b3min: npt.NDArray[float],
                       thesis: bool) -> Tuple[npt.NDArray[float], npt.NDArray[float]]:

--- a/environment.yml
+++ b/environment.yml
@@ -14,3 +14,4 @@ dependencies:
   - scipy
   - coverage
   - requests
+  - graphene-django

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,6 @@ dependencies:
   - pytest
   - pytz
   - tabulate
-  - tqdm
   - scipy
   - coverage
   - requests

--- a/environment.yml
+++ b/environment.yml
@@ -13,4 +13,3 @@ dependencies:
   - scipy
   - coverage
   - requests
-  - graphene-django

--- a/scripts/export_atoms.py
+++ b/scripts/export_atoms.py
@@ -1,14 +1,15 @@
+import logging
 import os
-
-from api.ocs import read_ocs_zipfile, OcsProgramProvider
-from common.output import atoms_to_sheet, print_collector_info
-from collector import *
+from astropy.time import Time, TimeDelta
+import astropy.units as u
+from common.minimodel import ALL_SITES, ObservationClass, ProgramTypes, Semester, SemesterHalf
+from api.programprovider.ocs import read_ocs_zipfile, OcsProgramProvider
+from common.output import atoms_to_sheet
+from components.collector import Collector
 
 
 if __name__ == '__main__':
-    # Reduce logging to ERROR only to display the tqdm bars nicely.
     logging.basicConfig(level=logging.INFO)
-    # logging.basicConfig(level=logging.ERROR)
 
     # Read in a list of JSON data
     programs = read_ocs_zipfile(os.path.join('..', 'data', '2018B_program_samples.zip'))
@@ -17,8 +18,8 @@ if __name__ == '__main__':
     collector = Collector(
         start_time=Time("2018-10-01 08:00:00", format='iso', scale='utc'),
         end_time=Time("2018-10-03 08:00:00", format='iso', scale='utc'),
-        time_slot_length=1.0 * u.min,
-        sites={Site.GN, Site.GS},
+        time_slot_length=TimeDelta(1.0 * u.min),
+        sites=ALL_SITES,
         semesters={Semester(2018, SemesterHalf.B)},
         program_types={ProgramTypes.Q, ProgramTypes.LP, ProgramTypes.FT, ProgramTypes.DD},
         obs_classes={ObservationClass.SCIENCE, ObservationClass.PROGCAL, ObservationClass.PARTNERCAL}
@@ -27,7 +28,7 @@ if __name__ == '__main__':
                             data=programs)
 
     # Output the state of and information calculated by the Collector.
-    #print_collector_info(collector, samples=60)
+    # print_collector_info(collector, samples=60)
     
     # Output the data in a spreadsheet.
     for program in collector.get_program_ids():

--- a/scripts/run_scheduler.py
+++ b/scripts/run_scheduler.py
@@ -11,9 +11,7 @@ from components.selector import Selector
 from components.optimizer import Optimizer
 
 if __name__ == '__main__':
-    # Reduce logging to ERROR only to display the tqdm bars nicely.
     logging.basicConfig(level=logging.INFO)
-    # logging.basicConfig(level=logging.ERROR)
 
     # Read in a list of JSON data
     programs = read_ocs_zipfile(os.path.join('..', 'data', '2018B_program_samples.zip'))

--- a/scripts/run_scheduler.py
+++ b/scripts/run_scheduler.py
@@ -22,7 +22,7 @@ if __name__ == '__main__':
     collector = Collector(
         start_time=Time("2018-10-01 08:00:00", format='iso', scale='utc'),
         end_time=Time("2018-10-03 08:00:00", format='iso', scale='utc'),
-        time_slot_length=1.0 * u.min,
+        time_slot_length=TimeDelta(1.0 * u.min),
         sites=ALL_SITES,
         semesters={Semester(2018, SemesterHalf.B)},
         program_types={ProgramTypes.Q, ProgramTypes.LP, ProgramTypes.FT, ProgramTypes.DD},


### PR DESCRIPTION
This fixes several things:

- Some of the typehints in the `Plans` code was incorrect.
- The `sky` library was not using `Moon.time_by_altitude` on moon set, so a triple was returned instead of the correct value.
- Times were not being wrapped correctly in `AstroPy``Time` and `TimeDelta` objects. This led them to have type `Quantity` instead of `Time` or `TimeDelta`, which was causing problems.
- Fix (possibly temporary) for FPUs that have a value of `None` during atom extraction.
- Remove tqdm, add Django (for now for GraphQL).
- Output fixes and commenting out uninformative logging info.