### PR TITLE
SCHED-172: Add properties to ObservatoryProperties for instrument calculations

### DIFF
--- a/api/observatory/abstract/__init__.py
+++ b/api/observatory/abstract/__init__.py
@@ -1,5 +1,6 @@
-from abc import ABC
-from typing import Set
+from abc import abstractmethod, ABC
+from datetime import timedelta
+from typing import Optional, Set
 
 from astropy import units as u
 from astropy.time import Time
@@ -14,6 +15,7 @@ class ObservatoryProperties(ABC):
     """
 
     @staticmethod
+    @abstractmethod
     def determine_standard_time(resources: Set[Resource],
                                 wavelengths: Set[float],
                                 modes: Set[ObservationMode],
@@ -26,4 +28,21 @@ class ObservatoryProperties(ABC):
         TODO: Based on the Gemini code, it seems like the latter is the case, but we do have
         TODO: the obsmode code in the atom extraction which provides an ObservationMode.
         """
-        return 0. * u.h
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def is_instrument(resource: Resource) -> bool:
+        """
+        Determine if the given resource is an instrument or not.
+        """
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def acquisition_time(resource: Resource, observation_mode: ObservationMode) -> Optional[timedelta]:
+        """
+        Given a resource, check if it is an instrument, and if so, lookup the
+        acquisition time for the specified mode.
+        """
+        ...

--- a/api/observatory/gemini/__init__.py
+++ b/api/observatory/gemini/__init__.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 from enum import Enum, EnumMeta
-from typing import Set
+from typing import Optional, Set
 
 import astropy.units as u
 from astropy.time import Time
@@ -50,6 +50,16 @@ class GeminiProperties(ObservatoryProperties):
             if ObservationMode.IMAGING in modes:
                 return 2.0 * u.h
             return 0.0 * u.h
+
+    @staticmethod
+    def is_instrument(resource: Resource) -> bool:
+        return resource in GeminiProperties.Instruments
+
+    @staticmethod
+    def acquisition_time(resource: Resource, observation_mode: ObservationMode) -> Optional[timedelta]:
+        if not GeminiProperties.is_instrument(resource):
+            return None
+        ...
 
 
 def with_igrins_cal(func):


### PR DESCRIPTION
We add to `ObservatoryProperties`:
1. `is_instrument`: determine if a `Resource` is an instrument.
2. `acquistion_time`: a lookup for acquisition time given an instrument and an `ObservationMode`.

Concrete implementations of these classes in `GeminiProperties`.