### PR TITLE
SCHED-175: Fix Env service usage for now.

### DIFF
--- a/components/selector/__init__.py
+++ b/components/selector/__init__.py
@@ -28,7 +28,9 @@ class Selector(SchedulerComponent):
     information is statically determined.
     """
     collector: Collector
-    _env: ClassVar[Env] = Env()
+
+    # TODO: Add when Env is complete.
+    # _env: ClassVar[Env] = Env()
 
     def select(self,
                sites: FrozenSet[Site] = ALL_SITES,
@@ -216,7 +218,9 @@ class Selector(SchedulerComponent):
         night_events = self.collector.get_night_events(obs.site)
 
         for night_idx in ranker.night_indices:
-            actual_conditions = Selector._env.get_actual_conditions_variant(obs.site, night_events.times[night_idx])
+            # TODO: Use Selector._env when the get actual conditions variant method doesn't return static data.
+            # actual_conditions = Selector._env.get_actual_conditions_variant(obs.site, night_events.times[night_idx])
+            actual_conditions = Env.get_actual_conditions_variant(obs.site, night_events.times[night_idx])
 
             # If we can obtain the conditions variant, calculate the conditions and wind mapping.
             # Otherwise, use arrays of all zeros to indicate that we cannot calculate this information.

--- a/mock/environment/__init__.py
+++ b/mock/environment/__init__.py
@@ -75,9 +75,8 @@ class Env:
                
                 self.site_data_by_night[site][night_date] = night_list
 
-
-    def get_actual_conditions_variant(self,
-                                      site: Site,
+    @staticmethod
+    def get_actual_conditions_variant(site: Site,
                                       times: Time) -> Optional[Variant]:
         """
         Return the weather variant.


### PR DESCRIPTION
There was a problem where we were instantiating the `Env` class, which was looking for files in its constructor and failing. 

This is a temporary fix until the `Env` model is complete.