### PR TITLE
SCHED-174: Fixed value and added attribution code.

### DIFF
--- a/common/sky/__init__.py
+++ b/common/sky/__init__.py
@@ -1,3 +1,17 @@
+"""
+All code in this package is a refactored, numpy-vectorized version of thorskyutil.py:
+
+https://github.com/jrthorstensen/thorsky/blob/master/thorskyutil.py
+
+utility and miscellaneous time and the sky routines built mostly on astropy.
+
+Copyright John Thorstensen, 2018; offered under the GNU Public License 3.0.
+
+Vectorized by Bryan Miller, Gemini Observatory.
+Refactored and clarified by Sergio Troncoso, Gemini Observatory.
+Modified by Sebastian Raaphorst, Gemini Observatory, to remove all deviations from Python 3.x PEP8 style guide.
+"""
+
 from .altitude import *
 from .brightness import *
 from .constants import *

--- a/common/sky/events.py
+++ b/common/sky/events.py
@@ -1,8 +1,7 @@
-from typing import Tuple, Union
+from typing import Tuple
 
 import astropy.units as u
 import numpy as np
-import numpy.typing as npt
 from astropy.coordinates import Angle, EarthLocation
 from astropy.time import Time
 from pytz import timezone

--- a/common/sky/utils.py
+++ b/common/sky/utils.py
@@ -267,7 +267,7 @@ def true_airmass(altit: Angle) -> npt.NDArray[float]:
         scalar_input = True
 
     # ret = np.zeros(len(altit))
-    ret = np.full(len(altit), -1.)
+    ret = np.full(len(altit), 500.)
     ii = np.where(altit > 0.0)[0][:]
     if len(ii) != 0:
         ret[ii] = 1. / np.sin(altit[ii])  # sec z = 1/sin (altit)


### PR DESCRIPTION
Re-adding modified attribution code for the modified and stylistically corrected `common.sky` package based on `thorskyutil.py`, and made airmass 500 instead of -1 for plots.