### PR TITLE
SCHED-243: Resources past last date in ResourceMock

### DIFF
--- a/mock/resource/__init__.py
+++ b/mock/resource/__init__.py
@@ -238,13 +238,11 @@ class ResourceMock(metaclass=Singleton):
         if site not in self._sites:
             raise ValueError(f'Request for resources for illegal site: {site.name}')
 
-        # If the date is before the first date, return an empty set.
-        if night_date < self._earliest_date_per_site[site]:
+        # If the date is before the first date or after the last date, return the empty set.
+        if night_date < self._earliest_date_per_site[site] or night_date > self._latest_date_per_site[site]:
             return frozenset()
 
-        # If the date is past the last date, return the resources on the last date.
-        actual_date = min(self._latest_date_per_site[site], night_date)
-        return frozenset(self._resources[site][actual_date])
+        return frozenset(self._resources[site][night_date])
 
     def get_resources_for_sites(self,
                                 sites: Collection[Site],

--- a/mock/resource/test/test_resource_mock.py
+++ b/mock/resource/test/test_resource_mock.py
@@ -52,6 +52,6 @@ def test_early_date(year):
 
 def test_late_date(year):
     latest_date = ResourceMock().date_range_for_site(Site.GN)[1]
-    expected = ResourceMock().get_resources(Site.GN, latest_date)
+    expected = frozenset()
     resources = ResourceMock().get_resources(Site.GN, latest_date + year)
     assert resources == expected


### PR DESCRIPTION
Beforehand, in `ResourceMock`, if `Resource` information was requested for a date that was past the last date for which `Resource` data existed, we would return the `Resource` information for the last date for which it was designed.

As per conversation with Bryan yesterday, we should instead return an empty set. This should not be a problem in practice because while the files containing FPU information and grating information may extend past the last date in the files (in which case asking for a date just after the last entry should return the last `Resources` as defined in those files), the Excel spreadsheet containing telescope configuration information has an entry for each valid date, so it will be guaranteed that data will exist for the entire range of dates.