### PR TITLE
SCHED-253: Changed logic to zero out observation times and move it earlier in code for res_visibility_time.

### DIFF
--- a/app/core/components/collector/test/test_clear_observation_info.py
+++ b/app/core/components/collector/test/test_clear_observation_info.py
@@ -23,11 +23,14 @@ def test_clear_observations():
     program_data = read_ocs_zipfile(os.path.join(ROOT_DIR, 'app', 'data', '2018B_program_samples.zip'))
     programs = [program_provider.parse_program(data['PROGRAM_BASIC']) for data in program_data]
 
-    # Clear the observations.
-    Collector.clear_observation_info(programs)
+    for program in programs:
+        for obs in program.observations():
+            Collector.clear_observation_info(obs)
 
     # Check to make sure all data has been cleared.
     for p in programs:
+        if p.program_used() != zero:
+            print('hello')
         assert p.program_used() == zero
         assert p.partner_used() == zero
         assert p.total_used() == zero

--- a/app/core/components/collector/test/test_clear_observation_info.py
+++ b/app/core/components/collector/test/test_clear_observation_info.py
@@ -29,8 +29,6 @@ def test_clear_observations():
 
     # Check to make sure all data has been cleared.
     for p in programs:
-        if p.program_used() != zero:
-            print('hello')
         assert p.program_used() == zero
         assert p.partner_used() == zero
         assert p.total_used() == zero


### PR DESCRIPTION
Beforehand, for a list of programs, we cleared out the observation used program and partner time too late in the code, i.e. after calling `Collector._calculate_target_info`. Since this method uses the `Observation.total_time` method, the observation times must be cleared before the target info is calculated.

Now, instead of taking the list of `Program` and processing it, we simply iterate over the `Observation`s as they are read in and zero the `program_used` and `partner_used` in the component `Atom`s.