### PR TITLE
SCHED-254: Bug fix for elevation.

### DIFF
--- a/app/core/components/collector/__init__.py
+++ b/app/core/components/collector/__init__.py
@@ -303,7 +303,7 @@ class Collector(SchedulerComponent):
 
             # In the case where an observation has no constraint information or an elevation constraint
             # type of None, we use airmass default values.
-            if obs.constraints:
+            if obs.constraints and obs.constraints.elevation_type != ElevationType.NONE:
                 targ_prop = hourangle if obs.constraints.elevation_type is ElevationType.HOUR_ANGLE else airmass
                 elev_min = obs.constraints.elevation_min
                 elev_max = obs.constraints.elevation_max


### PR DESCRIPTION
This fixes a big with regards to elevation constraints for an observation.

**NOTE:** This should NOT be merged until Monday's tech meet to discuss a more thorough plan. This is the minimal change that can be made.

@stroncod This dramatically changes the plan output from the DummyOptimizer from:
```
+++++ NIGHT 1 +++++
Plan for site: GN
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-104-11
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-104-7
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-104-10
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-104-12
Plan for site: GS
```

to:

````
+++++ NIGHT 1 +++++
Plan for site: GN
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1393
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1455
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-104-11
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1417
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1413
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1407
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1427
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1451
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1453
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1477
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1351
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-104-7
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-108-24
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1358
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-103-7
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-108-28
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1447
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1330
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1337
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1379
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1372
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1344
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-108-22
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1435
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1478
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1425
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-104-12
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1429
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1423
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1405
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-103-16
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1449
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1431
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1443
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1415
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1316
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-108-5
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1457
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-104-10
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1433
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1441
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1421
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1419
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1445
	2018-09-30 19:59:00.000017-09:00   GN-2018B-Q-101-1386
Plan for site: GS
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-105-77
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-105-28
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-105-87
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-70
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-105-79
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-23
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-105-51
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-40
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-69
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-30
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-105-52
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-38
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-36
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-42
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-28
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-80
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-17
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-61
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-105-50
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-44
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-79
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-105-9
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-34
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-68
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-105-81
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-105-90
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-65
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-75
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-105-75
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-64
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-67
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-74
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-57
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-32
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-72
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-105-49
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-104-21
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-11
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-63
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-52
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-105-92
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-102-73
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-105-14
	2018-09-30 20:36:00.000005-03:00   GS-2018B-Q-104-7
```

so we should investigate this to make sure that things work as we expect.