### PR TITLE
HACK: Forcing zeroing out of observation times.

### DIFF
--- a/app/core/scheduler/modes.py
+++ b/app/core/scheduler/modes.py
@@ -40,7 +40,7 @@ class ValidationMode(SchedulerMode):
 
     @staticmethod
     def _clear_observation_info(obs: Iterable[Observation],
-                                obs_statuses_to_ready: FrozenSet[ObservationStatus],
+                                obs_statuses_to_ready: FrozenSet[ObservationStatus] = _obs_statuses_to_ready,
                                 observation_filter: Optional[Callable[[Observation], bool]] = None) -> NoReturn:
         """
         Given a single observation, clear the information associated with the observation.


### PR DESCRIPTION
Because we are not using the new Builder class yet in GreedyMax, this is a hack that needs to be reverted to automatically assume `ValidationMode` and clear all obs times for the requires obs classes.