### PR TITLE
SCHED-268: Major architectural changes to allow filtering on ObservationClasses in ProgramProviders and bug fixes

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -2,15 +2,7 @@
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 import os
-from dataclasses import dataclass
-from typing import FrozenSet, Union, List
 
-import astropy.units as u
-from astropy.time import TimeDelta
-from lucupy.minimodel.observation import ObservationClass
-from lucupy.minimodel.program import ProgramTypes
-from lucupy.minimodel.semester import Semester, SemesterHalf
-from lucupy.minimodel.site import Site, ALL_SITES
 from omegaconf import OmegaConf
 
 from definitions import ROOT_DIR
@@ -26,6 +18,7 @@ class ConfigurationError(Exception):
 
     def __init__(self, config_type: str, value: str):
         super().__init__(f'Configuration error: {config_type} {value} is invalid.')
+
 
 path = os.path.join(ROOT_DIR, 'config.yaml')
 config = OmegaConf.load(path)

--- a/app/core/builder/blueprint.py
+++ b/app/core/builder/blueprint.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
-from typing import FrozenSet, Union, List, Any
+from typing import Any, FrozenSet, List, Type, Union, TypeVar
 from enum import Enum
 
 from astropy.time import TimeDelta
@@ -16,25 +16,29 @@ from app.core.components.optimizer.dummy import DummyOptimizer
 from mock.resource import ResourceMock
 from mock.environment import Env
 
+T = TypeVar('T')
 
-def parse_configuration(enum: Enum, value: str) -> Any:
+
+def parse_configuration(enum_class: Type[T], value: str) -> Any:
     """General parser for config.yml
 
 
     Args:
-        enum (Enum): Enum corresponding to the setting to parse
-        value (str): Value on config.yml
+        enum_class (Type): Enum corresponding to the setting to parse
+        value     (str): Value on config.yml
 
     Raises:
         ConfigurationError: General configuration error in case the string
 
     Returns:
-        Any: The represent selection on the Enum.
+        Any: The selection from the Enum.
     """
     try:
-        return enum[value]
+        return enum_class[value]
+    except TypeError:
+        raise ConfigurationError('Enum type', value)
     except ValueError:
-        raise ConfigurationError(enum.name, value)
+        raise ConfigurationError(enum_class.__name__, value)
 
 
 class Blueprint:
@@ -47,15 +51,20 @@ class CollectorBlueprint(Blueprint):
     """Blueprint for the Collector.
     This is based on the configuration in config.yml.
     """
+
     def __init__(self,
                  semesters: List[str],
                  obs_class: List[str],
                  prg_type: List[str],
-                 sites: Union[str,List[str]],
+                 sites: Union[str, List[str]],
                  time_slot_length: float) -> None:
-        self.semesters: FrozenSet[Semester] =  frozenset(map(CollectorBlueprint._parse_semesters, semesters))
-        self.obs_classes: FrozenSet[ObservationClass] = frozenset(map(lambda x: parse_configuration(ObservationClass, x), obs_class))
-        self.program_types: FrozenSet[ProgramTypes] = frozenset(map(lambda x: parse_configuration(ProgramTypes, x), prg_type))
+        self.semesters: FrozenSet[Semester] = frozenset(map(CollectorBlueprint._parse_semesters, semesters))
+        self.obs_classes: FrozenSet[ObservationClass] = frozenset(
+            map(lambda x: parse_configuration(ObservationClass, x), obs_class)
+        )
+        self.program_types: FrozenSet[ProgramTypes] = frozenset(
+            map(lambda x: parse_configuration(ProgramTypes, x), prg_type)
+        )
         self.sites: FrozenSet[Site] = CollectorBlueprint._parse_sites(sites)
         self.time_slot_length: TimeDelta = TimeDelta(time_slot_length * u.min)
 
@@ -83,7 +92,7 @@ class CollectorBlueprint(Blueprint):
         try:
             return Semester(int(year), e_half)
         except ValueError:
-            raise ConfigurationError('Semester year', year)    
+            raise ConfigurationError('Semester year', year)
 
     @staticmethod
     def _parse_sites(sites: Union[str, List[str]]) -> FrozenSet[Site]:
@@ -104,9 +113,10 @@ class CollectorBlueprint(Blueprint):
                 return Site.GN
             else:
                 raise ConfigurationError('Missing site', site)
+
         if sites == 'ALL_SITES':
-        # In case of ALL_SITES option, return lucupy alias for the set of all Site enums
-            return ALL_SITES 
+            # In case of ALL_SITES option, return lucupy alias for the set of all Site enums
+            return ALL_SITES
 
         if isinstance(sites, list):
             return frozenset(map(parse_specific_site, sites))
@@ -117,47 +127,49 @@ class CollectorBlueprint(Blueprint):
     def __iter__(self):
         return iter((self.time_slot_length,
                      self.sites,
-                     self.semesters, 
+                     self.semesters,
                      self.program_types,
                      self.obs_classes))
+
 
 class OptimizerBlueprint(Blueprint):
     """Blueprint for the Selector.
     This is based on the configuration in config.yml.
     """
-    
+
     def __init__(self, algorithm: str) -> None:
         self.algorithm = OptimizerBlueprint._parse_optimizer(algorithm)
-    
+
     @staticmethod
     def _parse_optimizer(algorithm_name: str):
         # TODO: Enums are needed but for now is just Dummy
         # TODO: When GMax is ready we can expand
-        if algorithm_name in 'DUMMY':
+        if algorithm_name.upper() == 'DUMMY':
             return DummyOptimizer()
         else:
             raise ConfigurationError('Optimizer', config.optimizer.name)
+
     def __iter__(self):
-        return iter((self.algorithm))
+        # return iter((self.algorithm))
+        return iter([self.algorithm])
+
 
 class SourcesBlueprint(Blueprint):
-    
     class ResourceSources(Enum):
         MOCK = ResourceMock()
         # TODO: As in full fledge service? I'm not sure about this name 
         # so suggestions are welcome. 
         FULL = None
-    
+
     class EnvSources(Enum):
         MOCK = Env()
         # TODO: This need to be hookup to the real service.
-        FULL = None 
-
+        FULL = None
 
     def __init__(self, resource_source: str, env_source: str):
         self.resource = parse_configuration(SourcesBlueprint.ResourceSources, resource_source).value
         self.environment = parse_configuration(SourcesBlueprint.EnvSources, env_source).value
-    
+
 
 class Blueprints:
     collector: CollectorBlueprint = CollectorBlueprint(config.collector.semesters,

--- a/app/core/builder/blueprint.py
+++ b/app/core/builder/blueprint.py
@@ -41,6 +41,7 @@ class Blueprint:
     """
     pass
 
+
 class CollectorBlueprint(Blueprint):
     """Blueprint for the Collector.
     This is based on the configuration in config.yml.

--- a/app/core/builder/blueprint.py
+++ b/app/core/builder/blueprint.py
@@ -36,6 +36,7 @@ def parse_configuration(enum: Enum, value: str) -> Any:
     except ValueError:
         raise ConfigurationError(enum.name, value)
 
+
 class Blueprint:
     """Base class for Blueprint
     """

--- a/app/core/builder/blueprint.py
+++ b/app/core/builder/blueprint.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
-from typing import Any, FrozenSet, List, Type, Union, TypeVar
+from typing import Any, FrozenSet, List, Type, Union
 from enum import Enum
 
 from astropy.time import TimeDelta
@@ -16,12 +16,9 @@ from app.core.components.optimizer.dummy import DummyOptimizer
 from mock.resource import ResourceMock
 from mock.environment import Env
 
-T = TypeVar('T')
 
-
-def parse_configuration(enum_class: Type[T], value: str) -> Any:
+def parse_configuration(enum_class: Type[Enum], value: str) -> Any:
     """General parser for config.yml
-
 
     Args:
         enum_class (Type): Enum corresponding to the setting to parse

--- a/app/core/builder/builder.py
+++ b/app/core/builder/builder.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 from typing import Iterable
 
 from astropy.time import Time
@@ -11,6 +12,7 @@ from app.core.components.selector import Selector
 from app.core.components.optimizer import Optimizer
 from app.core.scheduler.modes import dispatch_with
 from app.config import config
+
 
 @dispatch_with(config.mode)
 class SchedulerBuilder:

--- a/app/core/calculations/targetinfo.py
+++ b/app/core/calculations/targetinfo.py
@@ -45,6 +45,7 @@ class TargetInfo:
     airmass: npt.NDArray[float]
     sky_brightness: npt.NDArray[SkyBackground]
     visibility_slot_idx: npt.NDArray[int]
+    visibility_slot_filter: npt.NDArray[int]
     visibility_time: TimeDelta
     rem_visibility_time: TimeDelta
     rem_visibility_frac: float

--- a/app/core/components/collector/__init__.py
+++ b/app/core/components/collector/__init__.py
@@ -333,6 +333,11 @@ class Collector(SchedulerComponent):
                 )[0]
                 visibility_slot_idx = np.append(visibility_slot_idx, sa_idx[c_idx[tw_idx]])
 
+            # Create a visibility filter that has an entry for every time slot over the night,
+            # with 0 if the target is not visible and 1 if it is visible.
+            visibility_slot_filter = np.zeros(len(night_events.times[night_idx]))
+            visibility_slot_filter.put(visibility_slot_idx, 1.0)
+
             # TODO: Guide star availability for moving targets and parallactic angle modes.
 
             # Calculate the visibility time, the ongoing summed remaining visibility time, and
@@ -356,6 +361,7 @@ class Collector(SchedulerComponent):
                 airmass=airmass,
                 sky_brightness=sb,
                 visibility_slot_idx=visibility_slot_idx,
+                visibility_slot_filter=visibility_slot_filter,
                 visibility_time=visibility_time,
                 rem_visibility_time=rem_visibility_time,
                 rem_visibility_frac=rem_visibility_frac

--- a/app/core/components/selector/__init__.py
+++ b/app/core/components/selector/__init__.py
@@ -342,6 +342,7 @@ class Selector(SchedulerComponent):
                                      for sg in group.children]
             wind_score.append(np.multiply.reduce(wind_scores_for_night))
 
+        # The
         # The schedulable slot indices are the products of the schedulable slot indices for each subgroup across
         # each night.
         schedulable_slot_indices = []

--- a/app/core/components/selector/__init__.py
+++ b/app/core/components/selector/__init__.py
@@ -342,14 +342,17 @@ class Selector(SchedulerComponent):
                                      for sg in group.children]
             wind_score.append(np.multiply.reduce(wind_scores_for_night))
 
-        # The
-        # The schedulable slot indices are the products of the schedulable slot indices for each subgroup across
-        # each night.
-        schedulable_slot_indices = []
-        for night_idx in night_indices:
-            schedulable_slot_indices_for_night = [group_data_map[sg.id].group_info.schedulable_slot_indices[night_idx]
-                                                  for sg in group.children]
-            schedulable_slot_indices.append(np.multiply.reduce(schedulable_slot_indices_for_night))
+        # The schedulable slot indices are the unions of the schedulable slot indices for each subgroup
+        # across each night.
+        schedulable_slot_indices = [
+            # For each night, take the concatenation of the schedulable time slots for all children of the group
+            # and make it unique, which also puts it in sorted order.
+            np.unique(np.concatenate([
+                group_data_map[sg.id].group_info.schedulable_slot_indices[night_idx]
+                for sg in group.children
+            ]))
+            for night_idx in night_indices
+        ]
 
         # Calculate the scores for the group across all nights across all timeslots.
         scores = ranker.score_group(group)

--- a/app/core/programprovider/abstract/__init__.py
+++ b/app/core/programprovider/abstract/__init__.py
@@ -2,10 +2,11 @@
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 from abc import ABC, abstractmethod
-from typing import List
+from typing import FrozenSet, List
 
 from lucupy.minimodel import (AndGroup, Atom, Conditions, Constraints, Magnitude, NonsiderealTarget, Observation,
-    OrGroup, Program, QAState, SiderealTarget, Site, Target, TimeAllocation, TimingWindow)
+                              ObservationClass, OrGroup, Program, QAState, SiderealTarget, Site, Target, TimeAllocation,
+                              TimingWindow)
 
 
 class ProgramProvider(ABC):
@@ -25,9 +26,11 @@ class ProgramProvider(ABC):
     * NotImplementedError if the feature is not offered in this provider
     """
 
-    @staticmethod
+    def __init__(self, obs_classes: FrozenSet[ObservationClass]):
+        self._obs_classes = obs_classes
+
     @abstractmethod
-    def parse_program(data: dict) -> Program:
+    def parse_program(self, data: dict) -> Program:
         """
         Given an associative array that contains program data, retrieve the data
         and populate a top-level Program object.
@@ -40,9 +43,8 @@ class ProgramProvider(ABC):
         """
         ...
 
-    @staticmethod
     @abstractmethod
-    def parse_or_group(data: dict, group_id: str) -> OrGroup:
+    def parse_or_group(self, data: dict, group_id: str) -> OrGroup:
         """
         Given an associative array that contains the data needed for an OR group,
         retrieve the data and populate the OrGroup.
@@ -58,9 +60,8 @@ class ProgramProvider(ABC):
         """
         ...
 
-    @staticmethod
     @abstractmethod
-    def parse_and_group(data: dict, group_id: str) -> AndGroup:
+    def parse_and_group(self, data: dict, group_id: str) -> AndGroup:
         """
         Given an associative array that contains the data needed for an AND group,
         retrieve the data and populate the AndGroup.
@@ -76,9 +77,8 @@ class ProgramProvider(ABC):
         """
         ...
 
-    @staticmethod
     @abstractmethod
-    def parse_observation(data: dict, num: int) -> Observation:
+    def parse_observation(self, data: dict, num: int) -> Observation:
         """
         Given an associative array that contains observation data, retrieve the data
         and populate an Observation object.
@@ -94,9 +94,8 @@ class ProgramProvider(ABC):
         """
         ...
 
-    @staticmethod
     @abstractmethod
-    def parse_target(data: dict) -> Target:
+    def parse_target(self, data: dict) -> Target:
         """
         Given an associative array that contains common target data, retrieve the general
         data and populate a Target object.
@@ -112,9 +111,8 @@ class ProgramProvider(ABC):
         """
         ...
 
-    @staticmethod
     @abstractmethod
-    def parse_sidereal_target(data: dict) -> SiderealTarget:
+    def parse_sidereal_target(self, data: dict) -> SiderealTarget:
         """
         Given an associative array that contains sidereal target data, retrieve the sidereal
         data and populate a SiderealTarget object.
@@ -123,9 +121,8 @@ class ProgramProvider(ABC):
         """
         ...
 
-    @staticmethod
     @abstractmethod
-    def parse_nonsidereal_target(data: dict) -> NonsiderealTarget:
+    def parse_nonsidereal_target(self, data: dict) -> NonsiderealTarget:
         """
         Given an associative array that contains nonsidereal target data, retrieve the nonsidereal
         data and populate a NonsiderealTarget object.
@@ -134,18 +131,16 @@ class ProgramProvider(ABC):
         """
         ...
 
-    @staticmethod
     @abstractmethod
-    def parse_magnitude(data: dict) -> Magnitude:
+    def parse_magnitude(self, data: dict) -> Magnitude:
         """
         Given an associative array that contains magnitude data, retrieve the data
         and populate a Magnitude object.
         """
         ...
 
-    @staticmethod
     @abstractmethod
-    def parse_constraints(data: dict) -> Constraints:
+    def parse_constraints(self, data: dict) -> Constraints:
         """
         Given an associative array that contains constraints data, retrieve the data
         and populate a Constraints object.
@@ -156,9 +151,8 @@ class ProgramProvider(ABC):
         """
         ...
 
-    @staticmethod
     @abstractmethod
-    def parse_conditions(data: dict) -> Conditions:
+    def parse_conditions(self, data: dict) -> Conditions:
         """
         Given an associative array that contains conditions data, retrieve the data and
         populate a Conditions object.
@@ -168,9 +162,8 @@ class ProgramProvider(ABC):
         """
         ...
 
-    @staticmethod
     @abstractmethod
-    def parse_timing_window(data: dict) -> TimingWindow:
+    def parse_timing_window(self, data: dict) -> TimingWindow:
         """
         Given an associative array that contains the data for a single timing window,
         retrieve the data and populate a TimingWindow object.
@@ -180,9 +173,8 @@ class ProgramProvider(ABC):
         """
         ...
 
-    @staticmethod
     @abstractmethod
-    def parse_time_allocation(data: dict) -> TimeAllocation:
+    def parse_time_allocation(self, data: dict) -> TimeAllocation:
         """
         Given an associative array that contains the data for a single time allocation,
         retrieve the data and populate a TimeAllocation object.
@@ -192,9 +184,8 @@ class ProgramProvider(ABC):
         """
         ...
 
-    @staticmethod
     @abstractmethod
-    def parse_atoms(site: Site, sequence: List[dict], qa_states: List[QAState]) -> List[Atom]:
+    def parse_atoms(self, site: Site, sequence: List[dict], qa_states: List[QAState]) -> List[Atom]:
         """
         Given a list of associative arrays from an observation that contain atom data,
         parse / process the atom data and populate a list of Atom objects.

--- a/app/core/programprovider/ocs/__init__.py
+++ b/app/core/programprovider/ocs/__init__.py
@@ -949,7 +949,8 @@ class OcsProgramProvider(ProgramProvider):
                         for obs_key, obs_data in obs_data_blocks)
 
         # Parse out all the undesirable Observation Classes.
-        bad_obs, good_obs = partition(lambda x: x.obs_class in OcsProgramProvider._OBSCLASS_FILTERED, observations)
+        # partition returns a pair where of items where the predicate is False, and then where it is True.
+        good_obs, bad_obs = partition(lambda x: x.obs_class in OcsProgramProvider._OBSCLASS_FILTERED, observations)
 
         for obs in bad_obs:
             name = obs.obs_class.name

--- a/app/core/programprovider/ocs/test/test_ocs_api.py
+++ b/app/core/programprovider/ocs/test/test_ocs_api.py
@@ -6,10 +6,11 @@ import os
 from datetime import datetime, timedelta
 
 from lucupy.helpers import dmsstr2deg
-from lucupy.minimodel import AndGroup, AndOption, Atom, Band, CloudCover, Conditions, Constraints, ElevationType, \
-    ImageQuality, Magnitude, MagnitudeBands, Observation, ObservationClass, ObservationStatus, Priority, Program, \
-    ProgramMode, ProgramTypes, QAState, Resource, Semester, SemesterHalf, SetupTimeType, SiderealTarget, Site, \
-    SkyBackground, TargetType, TimeAccountingCode, TimeAllocation, TimingWindow, TooType, WaterVapor
+from lucupy.minimodel import (AndGroup, AndOption, Atom, Band, CloudCover, Conditions, Constraints, ElevationType,
+                              ImageQuality, Magnitude, MagnitudeBands, Observation, ObservationClass, ObservationStatus,
+                              Priority, Program, ProgramMode, ProgramTypes, QAState, Resource, Semester, SemesterHalf,
+                              SetupTimeType, SiderealTarget, Site, SkyBackground, TargetType, TimeAccountingCode,
+                              TimeAllocation, TimingWindow, TooType, WaterVapor)
 from lucupy.timeutils import sex2dec
 
 from app.core.programprovider.ocs import OcsProgramProvider
@@ -21,7 +22,8 @@ def get_api_program() -> Program:
     """
     with open(os.path.join('app', 'core', 'programprovider', 'ocs', 'test', 'GN-2022A-Q-999.json'), 'r') as f:
         data = json.loads(f.read())
-        return OcsProgramProvider.parse_program(data['PROGRAM_BASIC'])
+        obs_classes = frozenset({ObservationClass.SCIENCE, ObservationClass.PROGCAL, ObservationClass.PARTNERCAL})
+        return OcsProgramProvider(obs_classes).parse_program(data['PROGRAM_BASIC'])
 
 
 def create_minimodel_program() -> Program:
@@ -59,10 +61,10 @@ def create_minimodel_program() -> Program:
 
     gmosn2_target_1 = SiderealTarget(
         name='M11',
-        magnitudes={
+        magnitudes=frozenset({
             Magnitude(MagnitudeBands.B, 6.32),
             Magnitude(MagnitudeBands.V, 5.8)
-        },
+        }),
         type=TargetType.BASE,
         ra=sex2dec('18:51:03.840', todegree=True),
         dec=dmsstr2deg('353:43:40.80'),
@@ -73,7 +75,7 @@ def create_minimodel_program() -> Program:
 
     gmosn2_target_2 = SiderealTarget(
         name='419-102509',
-        magnitudes={
+        magnitudes=frozenset({
             Magnitude(MagnitudeBands.B, 12.261),
             Magnitude(MagnitudeBands.g, 12.046),
             Magnitude(MagnitudeBands.V, 11.983),
@@ -83,7 +85,7 @@ def create_minimodel_program() -> Program:
             Magnitude(MagnitudeBands.J, 11.11),
             Magnitude(MagnitudeBands.H, 11.0),
             Magnitude(MagnitudeBands.K, 10.894)
-        },
+        }),
         type=TargetType.GUIDESTAR,
         ra=sex2dec('18:50:50.990', todegree=True),
         dec=dmsstr2deg('353:44:28.68'),
@@ -106,8 +108,8 @@ def create_minimodel_program() -> Program:
             observed=False,
             qa_state=QAState.NONE,
             guide_state=False,
-            resources={gmosn},
-            wavelengths={0.475}
+            resources=frozenset({gmosn}),
+            wavelengths=frozenset({0.475})
         )
     ]
 
@@ -167,11 +169,11 @@ def create_minimodel_program() -> Program:
 
     gnirs2_target_1 = SiderealTarget(
         name='M22',
-        magnitudes={
+        magnitudes=frozenset({
             Magnitude(MagnitudeBands.B, 7.16),
             Magnitude(MagnitudeBands.V, 6.17),
             Magnitude(MagnitudeBands.K, 1.71)
-        },
+        }),
         type=TargetType.BASE,
         ra=sex2dec('18:36:23.940', todegree=True),
         dec=dmsstr2deg('336:05:42.90'),
@@ -182,7 +184,7 @@ def create_minimodel_program() -> Program:
 
     gnirs2_target_2 = SiderealTarget(
         name='331-171970',
-        magnitudes={
+        magnitudes=frozenset({
             Magnitude(MagnitudeBands.B, 12.888),
             Magnitude(MagnitudeBands.g, 11.93),
             Magnitude(MagnitudeBands.V, 11.051),
@@ -192,7 +194,7 @@ def create_minimodel_program() -> Program:
             Magnitude(MagnitudeBands.J, 7.754),
             Magnitude(MagnitudeBands.H, 6.993),
             Magnitude(MagnitudeBands.K, 6.769)
-        },
+        }),
         type=TargetType.GUIDESTAR,
         ra=sex2dec('18:36:36.196', todegree=True),
         dec=dmsstr2deg('336:00:20.55'),
@@ -216,8 +218,8 @@ def create_minimodel_program() -> Program:
             observed=False,
             qa_state=QAState.NONE,
             guide_state=False,
-            resources={gnirs},
-            wavelengths={2.2}
+            resources=frozenset({gnirs}),
+            wavelengths=frozenset({2.2})
         )
     ]
 
@@ -281,11 +283,11 @@ def create_minimodel_program() -> Program:
 
     gnirs1_target_1 = SiderealTarget(
         name='M10',
-        magnitudes={
+        magnitudes=frozenset({
             Magnitude(MagnitudeBands.g, value=6.842),
             Magnitude(MagnitudeBands.V, value=4.98),
             Magnitude(MagnitudeBands.K, value=3.6)
-        },
+        }),
         type=TargetType.BASE,
         ra=sex2dec('16:57:09.050', todegree=True),
         dec=dmsstr2deg('355:53:58.88'),
@@ -296,7 +298,7 @@ def create_minimodel_program() -> Program:
 
     gnirs1_target_2 = SiderealTarget(
         name='430-067087',
-        magnitudes={
+        magnitudes=frozenset({
             Magnitude(MagnitudeBands.V, value=11.78),
             Magnitude(MagnitudeBands.K, value=8.916),
             Magnitude(MagnitudeBands.i, value=11.04),
@@ -306,7 +308,7 @@ def create_minimodel_program() -> Program:
             Magnitude(MagnitudeBands.r, value=11.389),
             Magnitude(MagnitudeBands.H, value=9.082),
             Magnitude(MagnitudeBands.J, value=9.628)
-        },
+        }),
         type=TargetType.GUIDESTAR,
         ra=sex2dec('16:57:12.230', todegree=True),
         dec=dmsstr2deg('355:48:33.04'),
@@ -330,8 +332,8 @@ def create_minimodel_program() -> Program:
             observed=False,
             qa_state=QAState.NONE,
             guide_state=False,
-            resources={gnirs},
-            wavelengths={2.2}
+            resources=frozenset({gnirs}),
+            wavelengths=frozenset({2.2})
         )
     ]
 
@@ -411,13 +413,13 @@ def create_minimodel_program() -> Program:
 
     gmosn1_target_1 = SiderealTarget(
         name='M15',
-        magnitudes={
+        magnitudes=frozenset({
             Magnitude(MagnitudeBands.z, value=6.288),
             Magnitude(MagnitudeBands.r, value=6.692),
             Magnitude(MagnitudeBands.B, value=3.0),
             Magnitude(MagnitudeBands.i, value=6.439),
             Magnitude(MagnitudeBands.g, value=7.101)
-        },
+        }),
         type=TargetType.BASE,
         ra=sex2dec('21:29:58.330', todegree=True),
         dec=dmsstr2deg('12:10:01.20'),
@@ -428,7 +430,7 @@ def create_minimodel_program() -> Program:
 
     gmosn1_target_2 = SiderealTarget(
         name='512-132424',
-        magnitudes={
+        magnitudes=frozenset({
             Magnitude(MagnitudeBands.i, value=11.833),
             Magnitude(MagnitudeBands.J, value=10.455),
             Magnitude(MagnitudeBands.H, value=9.796),
@@ -438,7 +440,7 @@ def create_minimodel_program() -> Program:
             Magnitude(MagnitudeBands.K, value=9.695),
             Magnitude(MagnitudeBands.g, value=13.473),
             Magnitude(MagnitudeBands.V, value=12.834)
-        },
+        }),
         type=TargetType.GUIDESTAR,
         ra=sex2dec('21:29:54.924', todegree=True),
         dec=dmsstr2deg('12:13:22.47'),
@@ -449,7 +451,7 @@ def create_minimodel_program() -> Program:
 
     gmosn1_target_3 = SiderealTarget(
         name='512-132390',
-        magnitudes={
+        magnitudes=frozenset({
             Magnitude(MagnitudeBands.g, value=16.335),
             Magnitude(MagnitudeBands.B, value=16.708),
             Magnitude(MagnitudeBands.H, value=13.997),
@@ -458,7 +460,7 @@ def create_minimodel_program() -> Program:
             Magnitude(MagnitudeBands.K, value=13.845),
             Magnitude(MagnitudeBands.r, value=15.77),
             Magnitude(MagnitudeBands.J, value=14.455)
-        },
+        }),
         type=TargetType.TUNING_STAR,
         ra=sex2dec('21:29:46.873', todegree=True),
         dec=dmsstr2deg('12:12:57.61'),
@@ -469,12 +471,12 @@ def create_minimodel_program() -> Program:
 
     gmosn1_target_4 = SiderealTarget(
         name='511-136970',
-        magnitudes={
+        magnitudes=frozenset({
             Magnitude(MagnitudeBands.H, 13.003),
             Magnitude(MagnitudeBands.K, 12.884),
             Magnitude(MagnitudeBands.UC, 14.91),
             Magnitude(MagnitudeBands.J, 13.504)
-        },
+        }),
         type=TargetType.BLIND_OFFSET,
         ra=sex2dec('21:29:42.967', todegree=True),
         dec=dmsstr2deg('12:09:53.42'),
@@ -501,8 +503,8 @@ def create_minimodel_program() -> Program:
             observed=False,
             qa_state=QAState.NONE,
             guide_state=False,
-            resources={gmosn},
-            wavelengths={0.475}
+            resources=frozenset({gmosn}),
+            wavelengths=frozenset({0.475})
         )
     ]
 
@@ -567,7 +569,7 @@ def create_minimodel_program() -> Program:
         partner_used=timedelta()
     )
 
-    time_allocation = {time_allocation_us, time_allocation_ca}
+    time_allocation = frozenset({time_allocation_us, time_allocation_ca})
 
     # *** PROGRAM ***
     return Program(

--- a/app/core/scheduler/scheduler.py
+++ b/app/core/scheduler/scheduler.py
@@ -24,7 +24,7 @@ class Scheduler:
         
         # Retrieve observations from Collector
         collector = builder.build_collector(self.start_time, self.end_time, Blueprints.collector)
-        collector.load_programs(program_provider=OcsProgramProvider(),
+        collector.load_programs(program_provider_class=OcsProgramProvider,
                                 data=programs)
         # Create selection from Selector
         selector = builder.build_selector(collector)

--- a/app/core/scheduler/test/test_clear_observation_info.py
+++ b/app/core/scheduler/test/test_clear_observation_info.py
@@ -4,7 +4,7 @@
 from datetime import timedelta
 import os
 
-from lucupy.minimodel.observation import ObservationStatus
+from lucupy.minimodel.observation import ObservationClass, ObservationStatus
 
 from app.core.scheduler.modes import ValidationMode
 from app.core.programprovider.ocs import read_ocs_zipfile, OcsProgramProvider
@@ -15,7 +15,8 @@ def test_clear_observations():
     """
     Ensure the Collector clear_observation_info does as specified.
     """
-    program_provider = OcsProgramProvider()
+    obs_classes = frozenset({ObservationClass.SCIENCE, ObservationClass.PROGCAL, ObservationClass.PARTNERCAL})
+    program_provider = OcsProgramProvider(obs_classes)
     bad_status = frozenset([ObservationStatus.ONGOING, ObservationStatus.OBSERVED])
     zero = timedelta()
 

--- a/scripts/export_atoms.py
+++ b/scripts/export_atoms.py
@@ -29,7 +29,7 @@ if __name__ == '__main__':
         program_types=frozenset({ProgramTypes.Q, ProgramTypes.LP, ProgramTypes.FT, ProgramTypes.DD}),
         obs_classes=frozenset({ObservationClass.SCIENCE, ObservationClass.PROGCAL, ObservationClass.PARTNERCAL})
     )
-    collector.load_programs(program_provider=OcsProgramProvider(),
+    collector.load_programs(program_provider_class=OcsProgramProvider,
                             data=programs)
 
     # Output the state of and information calculated by the Collector.

--- a/scripts/run_scheduler.py
+++ b/scripts/run_scheduler.py
@@ -44,6 +44,10 @@ if __name__ == '__main__':
     # Execute the Selector.
     # Not sure the best way to display the output.
     selection = selector.select()
+    for pid, pinfo in selection.program_info.items():
+        for gid, gdata in pinfo.group_data.items():
+            group = gdata.group
+            print(f'PID: {pid}, GID: {gid}, observation: {group.is_observation_group()}, sched: {group.is_scheduling_group()}')
     program_data = selection.program_info['GN-2018B-Q-104']
     group_data = program_data.group_data['GN-2018B-Q-104-11']
     group = group_data.group

--- a/scripts/run_scheduler.py
+++ b/scripts/run_scheduler.py
@@ -33,7 +33,7 @@ if __name__ == '__main__':
         program_types=frozenset({ProgramTypes.Q, ProgramTypes.LP, ProgramTypes.FT, ProgramTypes.DD}),
         obs_classes=frozenset({ObservationClass.SCIENCE, ObservationClass.PROGCAL, ObservationClass.PARTNERCAL})
     )
-    collector.load_programs(program_provider=OcsProgramProvider(),
+    collector.load_programs(program_provider_class=OcsProgramProvider,
                             data=programs)
 
     # Output the state of and information calculated by the Collector.
@@ -44,13 +44,19 @@ if __name__ == '__main__':
     # Execute the Selector.
     # Not sure the best way to display the output.
     selection = selector.select()
+
+    # Print out the basic selection information, consisting of the programs that have been selected
+    # and whether they are observation or scheduling groups.
     for pid, pinfo in selection.program_info.items():
+        print(f'Program {pid}')
         for gid, gdata in pinfo.group_data.items():
             group = gdata.group
-            print(f'PID: {pid}, GID: {gid}, observation: {group.is_observation_group()}, sched: {group.is_scheduling_group()}')
-    program_data = selection.program_info['GN-2018B-Q-104']
-    group_data = program_data.group_data['GN-2018B-Q-104-11']
-    group = group_data.group
+            is_obs_group = group.is_observation_group()
+            print(f'\tGroup {gid} ({"Observation Group" if is_obs_group else "Scheduling Group"})')
+
+    # program_data = selection.program_info['GN-2018B-Q-104']
+    # group_data = program_data.group_data['GN-2018B-Q-104-11']
+    # group = group_data.group
     # print(group.exec_time())
     # print(group.total_used())
     # print(group.instruments())


### PR DESCRIPTION
Now, to the `Collector.load_programs` method, we pass a subclass of `ProgramProvider` instead of an instance.

This is done because the filtering on `Observation`s based on `ObservationClass` has to happen during the parsing of the JSON data instead of in the `Collector`: otherwise, we import all `Observation`s regardless of `ObservationClass`. This was causing `AndGroup`s to contain acquisitions and calibrations, and then when we did the filtering in `load_program`s, we would end up filtering out scheduling groups that contained any acquisitions or calibrations as a result since those `Observation`s were in the scheduling groups.

Now, `load_programs` instantiates the instance of `ProgramProvider` passed to it, giving it the `obs_classes` parameter that is part of the `Collector` initialization, and the filtering is done during parsing and we get the scheduling groups as required.

In addition to this, there is a major bugfix in the way that schedulable time slots (`GroupInfo.schedulable_slot_indices`) were handled for scheduling groups.

Since we were having all scheduling groups filtered out previously because of the above flaw, this bug only became apparent when the scheduling groups were included: it consisted of combining the schedulable time slots of `AndGroup`s that contained subgroups: this was failing because it was being treated as a 0-1 filter across all time slots per night instead of what it was, i.e. an array of the indices of the time slots per night.

Note that the former 0-1 filter approach would not work anyway, as we want an `AndGroup` to have the union (for now - this may change) of its children's schedulable time slots rather than the intersection, which is what we would get via combining these filters through multiplication.

The `TargetInfo.visibility_slot_index` member is what is used in part to determine the `schedulable_slot_indices` for `Observation`s, and thus that bubbles up to `AndGroup`s. In case the 0-1 filter is needed as well, I have also added a `TargetInfo.visibility_slot_filter` member.

Other minor corrections and fixes are in this PR as well, as well as formatting to PEP8 standards and eliminating warnings.

Minor corrections to the `blueprint.py` code: as `Enum` cannot be used as a type hint, this was changed to `Type[Enum]`.
Also, instead of checking if the optimizer configuration is in `"DUMMY"`, it is now uppercased and checked to be equal to `"DUMMY"`.