### PR TITLE
SCHED-258: Update interface with ResourceMock to use UTC dates

### DIFF
--- a/app/core/components/collector/__init__.py
+++ b/app/core/components/collector/__init__.py
@@ -453,5 +453,5 @@ class Collector(SchedulerComponent):
         Return a set of available resources for the night under consideration.
         """
         # ResourceMock works with dates and not night_idx, so we need to convert.
-        return [ResourceMock().get_resources(site, self.get_night_events(site).time_grid[night_idx].datetime.date())
+        return [ResourceMock().get_resources(site, self.get_night_events(site).time_grid[night_idx].datetime)
                 for night_idx in night_indices]

--- a/app/core/components/collector/__init__.py
+++ b/app/core/components/collector/__init__.py
@@ -6,7 +6,7 @@ import logging
 import time
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import ClassVar, Dict, FrozenSet, Iterable, List, NoReturn, Optional, Tuple, final
+from typing import ClassVar, Dict, FrozenSet, Iterable, List, NoReturn, Optional, Tuple, Type, final
 
 import astropy.units as u
 import numpy as np

--- a/app/core/components/collector/__init__.py
+++ b/app/core/components/collector/__init__.py
@@ -5,7 +5,8 @@ from inspect import isclass
 import logging
 import time
 from dataclasses import dataclass
-from typing import ClassVar, Dict, FrozenSet, Iterable, List, NoReturn, Optional, Tuple, Type, final
+from datetime import timedelta
+from typing import ClassVar, Dict, FrozenSet, Iterable, List, NoReturn, Optional, Tuple, final
 
 import astropy.units as u
 import numpy as np
@@ -21,7 +22,7 @@ from app.core.calculations import NightEvents, TargetInfo, TargetInfoMap, Target
 from app.core.components.base import SchedulerComponent
 from app.core.components.nighteventsmanager import NightEventsManager
 from app.core.programprovider.abstract import ProgramProvider
-# TODO HACK: This is a hack since Bryan cannot zero out the observation times in the current architecture.
+# TODO HACK: This is a hack to zero out the observation times in the current architecture from ValidationMode.
 from app.core.scheduler.modes import ValidationMode
 from mock.resource import ResourceMock
 
@@ -66,6 +67,9 @@ class Collector(SchedulerComponent):
     # We want the ObservationID in here so that any target sharing in GPP is deliberately split here, since
     # the target info is observation-specific due to the constraints and site.
     _target_info: ClassVar[TargetInfoMap] = {}
+
+    # Definition of a day to be used to get local dates for resources.
+    _DAY: ClassVar[timedelta] = timedelta(days=1)
 
     # The default timeslot length currently used.
     DEFAULT_TIMESLOT_LENGTH: ClassVar[Time] = 1.0 * u.min
@@ -452,6 +456,12 @@ class Collector(SchedulerComponent):
         """
         Return a set of available resources for the night under consideration.
         """
-        # ResourceMock works with dates and not night_idx, so we need to convert.
-        return [ResourceMock().get_resources(site, self.get_night_events(site).time_grid[night_idx].datetime)
+        # ResourceMock works with local dates and not UTC datetimes in the time_grid, so we need to convert.
+        # This is done by truncating the time and subtracting one day.
+        # TODO: In future, if we plan to extend to more observatories, we may have to rethink this strategy.
+
+        # Get singleton for convenience.
+        rm = ResourceMock()
+        return [rm.get_resources(site,
+                                 self.get_night_events(site).time_grid[night_idx].datetime.date() - Collector._DAY)
                 for night_idx in night_indices]

--- a/mock/resource/__init__.py
+++ b/mock/resource/__init__.py
@@ -221,7 +221,7 @@ class ResourceMock(metaclass=Singleton):
             self._all_resources[resource_id] = Resource(id=resource_id)
         return self._all_resources[resource_id]
 
-    def date_range_for_site(self, site: Site) -> Tuple[date, date]:
+    def date_range_for_site(self, site: Site) -> Tuple[datetime, datetime]:
         """
         Return the date range (inclusive) for which we have resource data for a site.
         """
@@ -229,24 +229,28 @@ class ResourceMock(metaclass=Singleton):
             raise ValueError(f'Request for resource dates for illegal site: {site.name}')
         return self._earliest_date_per_site[site], self._latest_date_per_site[site]
 
-    def get_resources(self, site: Site, night_date: date) -> FrozenSet[Resource]:
+    def get_resources(self, site: Site, night_date: datetime) -> FrozenSet[Resource]:
         """
-        For a site and a night date, return the set of available resources.
+        For a site and a night date (expressed as a datetime in UTC), return the set of available resources.
+        The datetime will be converted to a local date, as the data in this are represented by local dates.
         If the date falls before any resource data for the site, return the empty set.
         If the date falls after any resource data for the site, return the last resource set.
         """
         if site not in self._sites:
             raise ValueError(f'Request for resources for illegal site: {site.name}')
 
+        # Convert the night_date to the local date for the site.
+        local_night_date = night_date.astimezone(site.timezone).date()
+
         # If the date is before the first date or after the last date, return the empty set.
-        if night_date < self._earliest_date_per_site[site] or night_date > self._latest_date_per_site[site]:
+        if local_night_date < self._earliest_date_per_site[site] or local_night_date > self._latest_date_per_site[site]:
             return frozenset()
 
-        return frozenset(self._resources[site][night_date])
+        return frozenset(self._resources[site][local_night_date])
 
     def get_resources_for_sites(self,
                                 sites: Collection[Site],
-                                night_date: date) -> Dict[Site, FrozenSet[Resource]]:
+                                night_date: datetime) -> Dict[Site, FrozenSet[Resource]]:
         """
         For a collection of sites and a night date, return the set of available resources.
         """
@@ -254,7 +258,7 @@ class ResourceMock(metaclass=Singleton):
 
     def get_resources_for_dates(self,
                                 site: Site,
-                                night_dates: Collection[date]) -> Dict[date, FrozenSet[Resource]]:
+                                night_dates: Collection[datetime]) -> Dict[date, FrozenSet[Resource]]:
         """
         For a site and a collection of night dates, return the set of available resources.
         """
@@ -263,7 +267,8 @@ class ResourceMock(metaclass=Singleton):
 
     def get_resources_for_sites_and_dates(self,
                                           sites: Collection[Site],
-                                          night_dates: Collection[date]) -> Dict[Site, Dict[date, FrozenSet[Resource]]]:
+                                          night_dates: Collection[datetime])\
+            -> Dict[Site, Dict[date, FrozenSet[Resource]]]:
         """
         For a collection of sites and night dates, return the set of available resources.
         """
@@ -297,13 +302,12 @@ class ResourceMock(metaclass=Singleton):
 
 # For Bryan and Kristin: testing instructions
 if __name__ == '__main__':
-    # To get the Resources for a specific site on a specific date, modify the following:
+    # To get the Resources for a specific site on a specific date (UTC noon), modify the following:
     st = Site.GN
-    day = date(year=2018, month=11, day=8)
+    day = datetime(year=2018, month=11, day=8, hour=12)
 
     resources_available = ResourceMock().get_resources(st, day)
 
     print(f'*** Resources for site {st.name} for {day} ***')
     for resource in sorted(resources_available, key=lambda x: x.id):
         print(resource)
-    # print(', '.join([str(a) for a in sorted(resources_available, key=lambda x: x.id)]))

--- a/mock/resource/test/test_resource_mock.py
+++ b/mock/resource/test/test_resource_mock.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from datetime import datetime, time, timedelta
+from datetime import date, timedelta
 
 from lucupy.minimodel.resource import Resource
 from lucupy.minimodel.site import Site
@@ -13,11 +13,6 @@ from mock.resource import ResourceMock
 @pytest.fixture
 def year():
     return timedelta(days=365)
-
-
-@pytest.fixture
-def noon():
-    return time(hour=12)
 
 
 def test_specific_date_gn():
@@ -30,7 +25,7 @@ def test_specific_date_gn():
          Resource(id='11201501'), Resource(id='Altair'), Resource(id='B1200'), Resource(id='GCAL'),
          Resource(id='GMOS-N'), Resource(id='GNIRS'), Resource(id='Mirror'), Resource(id='NIRI'),
          Resource(id='R150'), Resource(id='R400')])
-    resources = ResourceMock().get_resources(Site.GN, datetime(year=2018, month=11, day=8, hour=12))
+    resources = ResourceMock().get_resources(Site.GN, date(year=2018, month=11, day=8))
     assert resources == expected
 
 
@@ -44,19 +39,19 @@ def test_specific_date_gs():
          Resource(id='Mirror'), Resource(id='B600'), Resource(id='R150'), Resource(id='R400'),
          Resource(id='Canopus'), Resource(id='Flamingos2'), Resource(id='GCAL'), Resource(id='GMOS-S'),
          Resource(id='GPI')])
-    resources = ResourceMock().get_resources(Site.GS, datetime(year=2018, month=12, day=30, hour=12))
+    resources = ResourceMock().get_resources(Site.GS, date(year=2018, month=12, day=30))
     assert resources == expected
 
 
-def test_early_date(year, noon):
+def test_early_date(year):
     earliest_date = ResourceMock().date_range_for_site(Site.GN)[0]
     expected = frozenset()
-    resources = ResourceMock().get_resources(Site.GN, datetime.combine(earliest_date, noon) - year)
+    resources = ResourceMock().get_resources(Site.GN, earliest_date - year)
     assert resources == expected
 
 
-def test_late_date(year, noon):
+def test_late_date(year):
     latest_date = ResourceMock().date_range_for_site(Site.GN)[1]
     expected = frozenset()
-    resources = ResourceMock().get_resources(Site.GN, datetime.combine(latest_date, noon) + year)
+    resources = ResourceMock().get_resources(Site.GN, latest_date + year)
     assert resources == expected

--- a/mock/resource/test/test_resource_mock.py
+++ b/mock/resource/test/test_resource_mock.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from datetime import date, timedelta
+from datetime import datetime, time, timedelta
 
 from lucupy.minimodel.resource import Resource
 from lucupy.minimodel.site import Site
@@ -13,6 +13,11 @@ from mock.resource import ResourceMock
 @pytest.fixture
 def year():
     return timedelta(days=365)
+
+
+@pytest.fixture
+def noon():
+    return time(hour=12)
 
 
 def test_specific_date_gn():
@@ -25,7 +30,7 @@ def test_specific_date_gn():
          Resource(id='11201501'), Resource(id='Altair'), Resource(id='B1200'), Resource(id='GCAL'),
          Resource(id='GMOS-N'), Resource(id='GNIRS'), Resource(id='Mirror'), Resource(id='NIRI'),
          Resource(id='R150'), Resource(id='R400')])
-    resources = ResourceMock().get_resources(Site.GN, date(year=2018, month=11, day=8))
+    resources = ResourceMock().get_resources(Site.GN, datetime(year=2018, month=11, day=8, hour=12))
     assert resources == expected
 
 
@@ -39,19 +44,19 @@ def test_specific_date_gs():
          Resource(id='Mirror'), Resource(id='B600'), Resource(id='R150'), Resource(id='R400'),
          Resource(id='Canopus'), Resource(id='Flamingos2'), Resource(id='GCAL'), Resource(id='GMOS-S'),
          Resource(id='GPI')])
-    resources = ResourceMock().get_resources(Site.GS, date(year=2018, month=12, day=30))
+    resources = ResourceMock().get_resources(Site.GS, datetime(year=2018, month=12, day=30, hour=12))
     assert resources == expected
 
 
-def test_early_date(year):
+def test_early_date(year, noon):
     earliest_date = ResourceMock().date_range_for_site(Site.GN)[0]
     expected = frozenset()
-    resources = ResourceMock().get_resources(Site.GN, earliest_date - year)
+    resources = ResourceMock().get_resources(Site.GN, datetime.combine(earliest_date, noon) - year)
     assert resources == expected
 
 
-def test_late_date(year):
+def test_late_date(year, noon):
     latest_date = ResourceMock().date_range_for_site(Site.GN)[1]
     expected = frozenset()
-    resources = ResourceMock().get_resources(Site.GN, latest_date + year)
+    resources = ResourceMock().get_resources(Site.GN, datetime.combine(latest_date, noon) + year)
     assert resources == expected


### PR DESCRIPTION
As per our discussion at the Scheduler meeting yesterday, this is a fix to use UTC dates to obtain Resource information from the mock, by chopping the datetime to a date and then subtracting one to get the correct date.

I accidentally committed these changes as SCHED-255, which is a UI issue.