### PR TITLE
SCHED-272: Fixing scoring algorithm for groups so that scores are now floats instead of ints.

### DIFF
--- a/app/core/components/ranker/base.py
+++ b/app/core/components/ranker/base.py
@@ -72,7 +72,6 @@ class Ranker:
         """
         Calculate the scores for each night and time slot of an AND Group.
         """
-        raise NotImplementedError
 
     @abstractmethod
     def _score_or_group(self, group: OrGroup) -> Scores:
@@ -81,4 +80,3 @@ class Ranker:
         TODO: This is TBD and requires more design work.
         TODO: In fact, OcsProgramProvider does not even support OR Groups.
         """
-        raise NotImplementedError


### PR DESCRIPTION
The `_default_score_combiner` was returning numpy arrays of type `int` instead of type `float`.
This was easily fixed by changing the `0` to a `0.` value.

I also cleaned up the code slightly and added comments so that the code can be more easily understood and maintained in the future.