### PR TITLE
SCHED-273: OcsProgramProvider now filters on active status.

### DIFF
--- a/app/core/programprovider/ocs/__init__.py
+++ b/app/core/programprovider/ocs/__init__.py
@@ -933,9 +933,15 @@ class OcsProgramProvider(ProgramProvider):
         observations = (self.parse_observation(obs_data, int(obs_key.split('-')[-1]))
                         for obs_key, obs_data in obs_data_blocks)
 
+        # Remove inactive observations.
+        inactive_obs, active_obs = partition(lambda x: x.active, observations)
+
+        for obs in inactive_obs:
+            logging.warning(f"Observation {obs.id} is inactive (skipping).")
+
         # Filter out all desirable Observation Classes.
         # partition returns a pair where of items where the predicate is False, and then where it is True.
-        bad_obs, good_obs = partition(lambda x: x.obs_class in self._obs_classes, observations)
+        bad_obs, good_obs = partition(lambda x: x.obs_class in self._obs_classes, active_obs)
 
         for obs in bad_obs:
             logging.warning(f'Observation {obs.id} not in a specified class (skipping): {obs.obs_class.name}.')

--- a/app/core/programprovider/ocs/test/test_ocs_filtering.py
+++ b/app/core/programprovider/ocs/test/test_ocs_filtering.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+# For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+import json
+import os
+from typing import FrozenSet, List
+
+import pytest
+
+from lucupy.minimodel import ObservationClass, Program
+
+from app.core.programprovider.ocs import read_ocs_zipfile, OcsProgramProvider
+from definitions import ROOT_DIR
+
+
+@pytest.fixture
+def obs_classes() -> FrozenSet[ObservationClass]:
+    return frozenset({ObservationClass.SCIENCE, ObservationClass.PROGCAL, ObservationClass.PARTNERCAL})
+
+
+@pytest.fixture
+def programs(obs_classes: FrozenSet[ObservationClass]) -> List[Program]:
+    program_provider = OcsProgramProvider(obs_classes)
+    program_data = read_ocs_zipfile(os.path.join(ROOT_DIR, 'app', 'data', '2018B_program_samples.zip'))
+    return [program_provider.parse_program(data['PROGRAM_BASIC']) for data in program_data]
+
+
+def test_obsclass_filtering(programs: List[Program], obs_classes: FrozenSet[ObservationClass]):
+    for program in programs:
+        for observation in program.root_group.observations():
+            assert observation.obs_class in obs_classes
+
+
+def test_inactive_filtering(programs: List[Program]):
+    for program in programs:
+        for observation in program.root_group.observations():
+            assert observation.active

--- a/app/core/scheduler/test/test_clear_observation_info.py
+++ b/app/core/scheduler/test/test_clear_observation_info.py
@@ -13,7 +13,7 @@ from definitions import ROOT_DIR
 
 def test_clear_observations():
     """
-    Ensure the Collector clear_observation_info does as specified.
+    Ensure the Validation clear_observation_info does as specified.
     """
     obs_classes = frozenset({ObservationClass.SCIENCE, ObservationClass.PROGCAL, ObservationClass.PARTNERCAL})
     program_provider = OcsProgramProvider(obs_classes)


### PR DESCRIPTION
Before, we were not filtering on the `active` status of `Observation`s when we were parsing in the `OcsProgramProvider`.

As a result, some inactive `Observation`s were making their way into the `Program`, and when the `Selector` was generating the `Selection`, these inactive `Observation`s were preventing certain scheduling `Group`s from being included  in the `Selection`.

This change now filters out based on the `active` property of `Observation`s.