### PR TITLE
SCHED-277: Populate Groups with program_id and change some structures to use UniqueGroupID

### DIFF
--- a/app/core/calculations/selection.py
+++ b/app/core/calculations/selection.py
@@ -26,8 +26,8 @@ class Selection:
     def show_groups(self) -> NoReturn:
         for prog_info in self.program_info.values():
             print(f'*** PROGRAM {prog_info.program.id}')
-            for group_id in prog_info.group_data.keys():
-                print(f'    {group_id}')
+            for group_info in prog_info.group_data.values():
+                print(f'    {group_info.group.unique_id()}')
 
     def __post_init__(self):
         object.__setattr__(self, 'program_ids', frozenset(self.program_info.keys()))

--- a/app/core/programprovider/abstract/__init__.py
+++ b/app/core/programprovider/abstract/__init__.py
@@ -4,9 +4,9 @@
 from abc import ABC, abstractmethod
 from typing import FrozenSet, List
 
-from lucupy.minimodel import (AndGroup, Atom, Conditions, Constraints, Magnitude, NonsiderealTarget, Observation,
-                              ObservationClass, OrGroup, Program, QAState, SiderealTarget, Site, Target, TimeAllocation,
-                              TimingWindow)
+from lucupy.minimodel import (AndGroup, Atom, Conditions, Constraints, GroupID, Magnitude, NonsiderealTarget,
+                              Observation, ObservationClass, OrGroup, Program, ProgramID, QAState, SiderealTarget,
+                              Site, Target, TimeAllocation, TimingWindow)
 
 
 class ProgramProvider(ABC):
@@ -44,7 +44,7 @@ class ProgramProvider(ABC):
         ...
 
     @abstractmethod
-    def parse_or_group(self, data: dict, group_id: str) -> OrGroup:
+    def parse_or_group(self, data: dict, program_id: ProgramID, group_id: GroupID) -> OrGroup:
         """
         Given an associative array that contains the data needed for an OR group,
         retrieve the data and populate the OrGroup.
@@ -61,7 +61,7 @@ class ProgramProvider(ABC):
         ...
 
     @abstractmethod
-    def parse_and_group(self, data: dict, group_id: str) -> AndGroup:
+    def parse_and_group(self, data: dict, program_id: ProgramID, group_id: GroupID) -> AndGroup:
         """
         Given an associative array that contains the data needed for an AND group,
         retrieve the data and populate the AndGroup.

--- a/app/core/programprovider/ocs/test/test_ocs_api.py
+++ b/app/core/programprovider/ocs/test/test_ocs_api.py
@@ -135,6 +135,7 @@ def create_minimodel_program() -> Program:
     # Create the trivial AND group containing the GMOSN-2 observation.
     gmosn2_group = AndGroup(
         id=gmosn2.id,
+        program_id=program_id,
         group_name=gmosn2.title,
         number_to_observe=1,
         delay_min=timedelta.min,
@@ -245,6 +246,7 @@ def create_minimodel_program() -> Program:
     # Create the trivial AND group containing the GNIRS-2 observation.
     gnirs2_group = AndGroup(
         id=gnirs2.id,
+        program_id=program_id,
         group_name=gnirs2.title,
         number_to_observe=1,
         delay_min=timedelta.min,
@@ -256,6 +258,7 @@ def create_minimodel_program() -> Program:
     # *** AND GROUP CONTAINING THE GMOSN-2 AND GNIRS-2 GROUPS ***
     sched_group = AndGroup(
         id='2',
+        program_id=program_id,
         group_name='TestGroup',
         number_to_observe=2,
         delay_min=timedelta.min,
@@ -359,6 +362,7 @@ def create_minimodel_program() -> Program:
     # Create the trivial AND group containing the gnirs1 observation.
     gnirs1_group = AndGroup(
         id=gnirs1_observation.id,
+        program_id=program_id,
         group_name='GNIRS-1',
         number_to_observe=1,
         delay_min=timedelta.min,
@@ -530,6 +534,7 @@ def create_minimodel_program() -> Program:
     # Create the trivial AND group containing the gnirs1 observation.
     gmosn1_group = AndGroup(
         id=gmosn1_observation.id,
+        program_id=program_id,
         group_name='GMOSN-1',
         number_to_observe=1,
         delay_min=timedelta.min,
@@ -543,8 +548,9 @@ def create_minimodel_program() -> Program:
     # root_children = [sched_group, gmosn1_group, gnirs1_group]
 
     root_group = AndGroup(
-        id='Root',
-        group_name='Root',
+        id='root',
+        program_id=program_id,
+        group_name='root',
         number_to_observe=3,
         delay_min=timedelta.min,
         delay_max=timedelta.max,


### PR DESCRIPTION
1. The `ProgramProvider` and `OcsProgramProvider` now both pass `program_id` to the `parse_xxx_group` methods since lucupy has changed to have a `program_id` field in `Group`.
2. The `Selector.get_group_info` method now takes a `UniqueGroupID` instead of `GroupID` since the `GroupID`s were not unique and scheduling groups were overwriting each other in the dictionary this manages.
3. The `Selection.show_groups()` method now displays, for each program, the `UniqueGroupID` rather than the `GroupID`.
4. Test cases fixed.