### PR TITLE
SCHED-278: Add schedulable_groups map to Selection

### DIFF
--- a/app/core/calculations/groupinfo.py
+++ b/app/core/calculations/groupinfo.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Dict, List
 
 import numpy.typing as npt
-from lucupy.minimodel import Conditions, Group, GroupID, ProgramID
+from lucupy.minimodel import Conditions, Group, GroupID
 
 from .scores import Scores
 
@@ -43,6 +43,10 @@ class GroupData:
     """
     group: Group
     group_info: GroupInfo
+
+    def __iter__(self):
+        # Make GroupData unpackable.
+        return iter((self.group, self.group_info))
 
 
 # Map to access GroupData from a GroupID in the ProgramInfo.

--- a/app/core/calculations/selection.py
+++ b/app/core/calculations/selection.py
@@ -21,11 +21,5 @@ class Selection:
     night_events: Mapping[Site, NightEvents]
     schedulable_groups: Mapping[UniqueGroupID, GroupData]
 
-    def show_groups(self) -> NoReturn:
-        for prog_info in self.program_info.values():
-            print(f'*** PROGRAM {prog_info.program.id}')
-            for group_info in prog_info.group_data.values():
-                print(f'    {group_info.group.unique_id()}')
-
     def __post_init__(self):
         object.__setattr__(self, 'program_ids', frozenset(self.program_info.keys()))

--- a/app/core/calculations/selection.py
+++ b/app/core/calculations/selection.py
@@ -4,8 +4,9 @@
 from dataclasses import dataclass
 from typing import Mapping, NoReturn
 
-from lucupy.minimodel import Group, ProgramID, Site
+from lucupy.minimodel import ProgramID, Site, UniqueGroupID
 
+from .groupinfo import GroupData
 from .nightevents import NightEvents
 from .programinfo import ProgramInfo
 
@@ -18,10 +19,7 @@ class Selection:
     """
     program_info: Mapping[ProgramID, ProgramInfo]
     night_events: Mapping[Site, NightEvents]
-
-    def show(self) -> NoReturn:
-        for prog_info in self.program_info.values():
-            prog_info.program.show()
+    schedulable_groups: Mapping[UniqueGroupID, GroupData]
 
     def show_groups(self) -> NoReturn:
         for prog_info in self.program_info.values():

--- a/app/core/components/selector/__init__.py
+++ b/app/core/components/selector/__init__.py
@@ -3,7 +3,7 @@
 
 import logging
 from dataclasses import dataclass
-from typing import ClassVar, Dict, FrozenSet, Optional
+from typing import ClassVar, Dict, FrozenSet, List, Optional
 
 import astropy.units as u
 import numpy as np
@@ -37,6 +37,27 @@ class Selector(SchedulerComponent):
     collector: Collector
 
     _wind_sep: ClassVar[Angle] = 20. * u.deg
+
+    @staticmethod
+    def _get_top_level_groups(group_data_map: GroupDataMap, program_id) -> List[GroupData]:
+        """
+        Given a GroupDataMap for a Program, filter to get the GroupData for the top-level Groups
+        except the root group.
+
+        A Group G is a top-level group if:
+        1. G is not the root group.
+        2. For any scheduling Group H in the GroupDataMap (except the root group), G is not a child of H.
+        """
+        print(f'*** SHRINKING {program_id} GROUPS ***')
+        print(f'Original: {sorted([group.unique_id() for (group, _) in group_data_map.values()])}')
+        scheduling_groups = [group for (group, _) in group_data_map.values()
+                             if group.id != 'root' and group.is_scheduling_group()]
+        shrunk = [group_data for group_data in group_data_map.values()
+                  if (group_data.group.id != 'root' and
+                      all(group_data.group not in other.children for other in scheduling_groups))]
+        print(f'Shrunk: {sorted([group.unique_id() for (group, _) in shrunk])}')
+        print('*************************************')
+        return shrunk
 
     def select(self,
                sites: FrozenSet[Site] = ALL_SITES,
@@ -86,6 +107,10 @@ class Selector(SchedulerComponent):
 
         # Create the structure to hold the mapping fom program ID to its group info.
         program_info: Dict[ProgramID, ProgramInfo] = {}
+
+        # A flat top-level list of GroupData indexed by UniqueGroupID.
+        schedulable_groups: Dict[UniqueGroupID, GroupData] = {}
+
         for program_id in Collector.get_program_ids():
             program = Collector.get_program(program_id)
             if program is None:
@@ -112,6 +137,11 @@ class Selector(SchedulerComponent):
 
             # This filters out any programs that have no groups with any schedulable slots.
             if group_data_map:
+                # Get the top-level groups (excluding root) in group_data_map and add to the schedulable_groups map.
+                top_level_group_data = Selector._get_top_level_groups(group_data_map, program_id)
+                for group_data in top_level_group_data:
+                    schedulable_groups[group_data.group.unique_id()] = group_data
+
                 # Remember that in an observation group, the only child is an Observation: hence references here
                 # to group.children are simply the Observation.
                 observations = {group_data.group.children.id: group_data.group.children
@@ -132,7 +162,8 @@ class Selector(SchedulerComponent):
         # at least one GroupInfo has schedulable slots.
         return Selection(
             program_info=program_info,
-            night_events={site: self.collector.get_night_events(site) for site in sites}
+            night_events={site: self.collector.get_night_events(site) for site in sites},
+            schedulable_groups=schedulable_groups
         )
 
     def get_group_info(self, unique_group_id: UniqueGroupID) -> Optional[GroupInfo]:

--- a/scripts/run_scheduler.py
+++ b/scripts/run_scheduler.py
@@ -55,9 +55,6 @@ if __name__ == '__main__':
     #         print(f'\tGroup {gid} ({"Observation Group" if is_obs_group else "Scheduling Group"})')
 
     print()
-    print('--- SELECTION ---')
-    selection.show()
-    print()
     print('--- GROUPS ---')
     selection.show_groups()
 

--- a/scripts/run_scheduler.py
+++ b/scripts/run_scheduler.py
@@ -45,26 +45,6 @@ if __name__ == '__main__':
     # Not sure the best way to display the output.
     selection = selector.select()
 
-    # Print out the basic selection information, consisting of the programs that have been selected
-    # and whether they are observation or scheduling groups.
-    # for pid, pinfo in selection    .program_info.items():
-    #     print(f'Program {pid}')
-    #     for gid, gdata in pinfo.group_data.items():
-    #         group = gdata.group
-    #         is_obs_group = group.is_observation_group()
-    #         print(f'\tGroup {gid} ({"Observation Group" if is_obs_group else "Scheduling Group"})')
-
-    print()
-    print('--- GROUPS ---')
-    selection.show_groups()
-
-    # program_data = selection.program_info['GN-2018B-Q-104']
-    # group_data = program_data.group_data['GN-2018B-Q-104-11']
-    # group = group_data.group
-    # print(group.exec_time())
-    # print(group.total_used())
-    # print(group.instruments())
-
     # Notes for data access:
     # The Selector returns all the data that an Optimizer needs in order to generate plans.
     # This comprises a Selection object, which has fields:
@@ -163,12 +143,6 @@ if __name__ == '__main__':
     #
     # selector.get_group_info(group_id).scores
     # selection.program_info(program_id).group_data(group_id).group_info.scores
-
-    # Sergio preliminary work:
-    # Output the data in a spreadsheet.
-    # for program in collector._programs.values():
-    #    if program.id == 'GS-2018B-Q-101':
-    #        atoms_to_sheet(program)
 
     # gm = GreedyMax(some_parameter=1)  # Set parameters for specific algorithm
     # print(selection.program_info)


### PR DESCRIPTION
1. Added a static method, `Selector._get_top_level_groups` that takes a `GroupDataMap` and extracts the `GroupData` objects that are defined as top-level (i.e. not the root and not contained in any scheduling group except possibly the root).
2. Added a map `schedulable_groups: Mapping[UniqueGroupID, GroupData]` to `Selection`.
3. Cleaned up a bunch of unnecessary output, commented out code, etc.