### PR TITLE
SCHED-285: Add CORS Middleware to FastAPI

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -2,8 +2,26 @@
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from app.graphql import graphql_server
 
 app = FastAPI()
+
+origins = [
+    "http://localhost",
+    "http://localhost:5173",
+    "https://schedule-subscriber-staging.herokuapp.com",
+    "https://gpp-schedule-staging.herokuapp.com",
+
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 app.add_route('/graphql', graphql_server)
 app.add_websocket_route('/graphql', graphql_server)


### PR DESCRIPTION
This blocks outside request to the Scheduler and satisfies the FrontEnd server requirements. 