### PR TITLE
SCHED-331: Removed has method, replaced with __contains__.

### DIFF
--- a/scheduler/core/components/optimizer/dummy.py
+++ b/scheduler/core/components/optimizer/dummy.py
@@ -69,8 +69,7 @@ class DummyOptimizer(BaseOptimizer):
             plan = plans[observation.site]
             if not plan.is_full and plan.site == observation.site:
                 obs_len = plan.time2slots(observation.exec_time())
-                if (plan.time_left() >= obs_len) and not plan.has(observation):
-                    # start = DummyOptimizer._allocate_time(plan, observation.exec_time())
+                if plan.time_left() >= obs_len and observation not in plan:
                     start = DummyOptimizer._allocate_time(plan)
                     plan.add(observation, start, obs_len)
                     return True

--- a/scheduler/core/components/optimizer/greedymax.py
+++ b/scheduler/core/components/optimizer/greedymax.py
@@ -120,7 +120,7 @@ class GreedyMaxOptimizer(BaseOptimizer):
             print(plan.time_left(), grp_len, group.group.exec_time())
             if plan.time_left() >= grp_len:
                 for observation in group.group.observations():
-                    if not plan.has(observation):
+                    if observation not in plan:
                         obs_len = plan.time2slots(observation.exec_time())
                         start = self._allocate_time(plan, observation.exec_time())
                         plan.add(observation, start, obs_len)

--- a/scheduler/core/plans/__init__.py
+++ b/scheduler/core/plans/__init__.py
@@ -45,7 +45,7 @@ class Plan:
         self.visits.append(visit)
         self._time_slots_left -= time_slots
 
-    def has(self, obs: Observation) -> bool:
+    def __contains__(self, obs: Observation) -> bool:
         return any(visit.obs_id == obs.id for visit in self.visits)
 
     def time_left(self) -> int:


### PR DESCRIPTION
Instead of `Plan.has`, we use `__contains__`.

Instead of doing:
```python
plan.has(obs)
```
or
```python
not plan.has(obs)
```
we can now do:
```python
obs in plan
```
and
```python
obs not in plan
```