### PR TITLE
SCHED-329: Fix test cases and HORIZONS code

### DIFF
--- a/scheduler/services/horizons/__init__.py
+++ b/scheduler/services/horizons/__init__.py
@@ -6,7 +6,7 @@ import contextlib
 import os
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Final, List, Tuple, final
+from typing import ClassVar, Final, List, Mapping, Tuple, final
 
 import dateutil.parser
 import numpy as np
@@ -121,29 +121,24 @@ class EphemerisCoordinates:
 
 
 @final
+@dataclass(frozen=True)
 class HorizonsClient:
     """
     API to interact with the Horizons service
     """
+    site: Site
+    path: str = os.path.join('scheduler', 'services', 'horizons', 'data')
+    airmass: int = 3
+    start: datetime = None
+    end: datetime = None
 
+    url: ClassVar[str] = 'https://ssd.jpl.nasa.gov/horizons_batch.cgi'
     # A not-complete list of solar system major body Horizons IDs
-    bodies = {'mercury': '199', 'venus': '299', 'mars': '499', 'jupiter': '599', 'saturn': '699',
-              'uranus': '799', 'neptune': '899', 'pluto': '999', 'io': '501'}
+    bodies: ClassVar[Mapping[str, str]] = {'mercury': '199', 'venus': '299', 'mars': '499', 'jupiter': '599',
+                                           'saturn': '699', 'uranus': '799', 'neptune': '899', 'pluto': '999',
+                                           'io': '501'}
 
-    FILE_DATE_FORMAT = '%Y%m%d_%H%M'
-
-    def __init__(self,
-                 site: Site,
-                 path: str = os.path.join('scheduler', 'services', 'horizons', 'data'),
-                 airmass: int = 3,
-                 start: datetime = None,
-                 end: datetime = None):
-        self.path = path
-        self.url = 'https://ssd.jpl.nasa.gov/horizons_batch.cgi'
-        self.start = start
-        self.end = end
-        self.airmass = airmass
-        self.site = site
+    FILE_DATE_FORMAT: ClassVar[str] = '%Y%m%d_%H%M'
 
     @staticmethod
     def generate_horizons_id(designation: str) -> str:

--- a/scheduler/services/horizons/__init__.py
+++ b/scheduler/services/horizons/__init__.py
@@ -64,8 +64,8 @@ class Coordinates:
 
     def angular_distance(self, other: 'Coordinates') -> float:
         """
-        Calculate the angular distance between two points on the sky.
-        based on
+        Calculate the angular distance between two points on the sky in radians.
+        Code is based on
         https://github.com/gemini-hlsw/lucuma-core/blob/master/modules/core/shared/src/main/scala/lucuma/core/math/Coordinates.scala#L52
         """
         phi_1 = self.dec
@@ -74,10 +74,10 @@ class Coordinates:
         delta_lambda = other.ra - self.ra
         a = np.around(np.sin(delta_phi / 2) ** 2, decimals=10) + np.around(np.cos(phi_1) * np.cos(phi_2) *
                                                                            np.sin(delta_lambda / 2) ** 2, decimals=10)
-        if 0 <= a <= 1:
-            return 2 * np.arctan2(np.sqrt(a), np.sqrt(1 - a))
-        else:
-            return 0.0  # TODO: Temporary bypass for negative values in sqrt
+        #if 0 <= a <= 1:
+        return 2 * np.arctan2(np.sqrt(a), np.sqrt(1 - a))
+        #else:
+        # return 0.0  # TODO: Temporary bypass for negative values in sqrt
 
     def interpolate(self, other: 'Coordinates', f: float) -> 'Coordinates':
         """

--- a/tests/unit/scheduler/external/horizons/test_horizons_client.py
+++ b/tests/unit/scheduler/external/horizons/test_horizons_client.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 import numpy as np
 import pytest
+from hypothesis import note
 from hypothesis import given, strategies as st
 from hypothesis.strategies import composite
 from lucupy.minimodel import Site, NonsiderealTarget, TargetTag, TargetType
@@ -15,7 +16,7 @@ from scheduler.services.horizons import Coordinates, HorizonsAngle, horizons_ses
 @composite
 def coordinates(draw):
     # RA is in [0, 2π) radians.
-    ra = draw(st.floats(min_value=0, max_value=np.pi, exclude_max=True))
+    ra = draw(st.floats(min_value=0, max_value=2 * np.pi, exclude_max=True))
 
     # Dec is in [-π, π] radians.
     dec = draw(st.floats(min_value=-np.pi / 2, max_value=np.pi/2))
@@ -74,28 +75,36 @@ def test_interpolation_by_angular_distance_for_factor_one(c1, c2):
     """
     Interpolate should result in angular distance of 0° from `b` for factor 1.0, within 1µsec (15µas)
     """
-    delta = c1.angular_distance(c1.interpolate(c2, 1.0))
+    delta = c2.angular_distance(c1.interpolate(c2, 1.0))
     assert abs(HorizonsAngle.to_signed_microarcseconds(delta)) <= 15
 
 
+# TODO: This test fails in a very small number of cases. The original test case in Scala
+# TODO: is marked as being flaky.
+# TODO: This seems to happen if the RAs or Decs are very close to pi radians in difference.
+# Examples of failing value:
+# c1=Coordinates(ra=0.0, dec=1.5707963263853362), c2=Coordinates(ra=0.0, dec=-1.5707963263853362), max_delta=3.1415926535897922 # noqa
 @given(c1=coordinates(), c2=coordinates())
-@pytest.mark.skip(reason='Cannot expect this level of precision from degrees.')
+# @pytest.mark.skip(reason='Very small number of failures in limited cases as described above.')
 def test_interpolation_by_fractional_angular_separation(c1, c2):
     """
-    Interpolate should be consistent with fractional angular separation, to within 20 µas
+    Interpolate should be consistent with fractional angular separation.
     """
+    threshold = 1e-3
+
     sep = c1.angular_distance(c2)
     deltas = []
 
     for f in np.arange(-1.0, 2.0, 0.1):
-        step_sep = HorizonsAngle.to_degrees(c1.angular_distance(c1.interpolate(c2, f)))
-        frac_sep = HorizonsAngle.to_degrees(sep * abs(f))
-        # TODO: CHECK THIS
-        frac_sep2 = frac_sep if frac_sep <= 180 else 360 - frac_sep
+        step_sep = c1.interpolate(c2, f).angular_distance(c1)
+        frac_sep = sep * abs(f)
+        frac_sep2 = frac_sep if frac_sep <= np.pi else 2 * np.pi - frac_sep
         deltas.append(abs(step_sep - frac_sep2))
     max_delta = max(deltas)
-    assert max_delta < 55
-
+    # c_ra_diff_close_to_pi = abs(abs(c1.ra - c2.ra) - np.pi) < threshold
+    # c_dec_diff_close_to_pi = abs(abs(c1.dec - c2.dec) - np.pi) < threshold
+    note(f'Interpolate - angular separation fail: {c1}, {c2}.')
+    assert max_delta < threshold
 
 def test_horizons_client_query(target: NonsiderealTarget,
                                session_parameters: dict):

--- a/tests/unit/scheduler/external/horizons/test_horizons_client.py
+++ b/tests/unit/scheduler/external/horizons/test_horizons_client.py
@@ -82,7 +82,7 @@ def test_interpolation_by_angular_distance_for_factor_one(c1, c2):
 # TODO: This test fails in a very small number of cases. The original test case in Scala
 # TODO: is marked as being flaky.
 # TODO: This seems to happen if the RAs or Decs are very close to pi radians in difference.
-# Examples of failing value:
+# Example of failing value:
 # c1=Coordinates(ra=0.0, dec=1.5707963263853362), c2=Coordinates(ra=0.0, dec=-1.5707963263853362), max_delta=3.1415926535897922 # noqa
 @given(c1=coordinates(), c2=coordinates())
 # @pytest.mark.skip(reason='Very small number of failures in limited cases as described above.')
@@ -104,7 +104,9 @@ def test_interpolation_by_fractional_angular_separation(c1, c2):
     # c_ra_diff_close_to_pi = abs(abs(c1.ra - c2.ra) - np.pi) < threshold
     # c_dec_diff_close_to_pi = abs(abs(c1.dec - c2.dec) - np.pi) < threshold
     note(f'Interpolate - angular separation fail: {c1}, {c2}.')
+    # assert c_ra_diff_close_to_pi or c_dec_diff_close_to_pi or max_delta < threshold
     assert max_delta < threshold
+
 
 def test_horizons_client_query(target: NonsiderealTarget,
                                session_parameters: dict):


### PR DESCRIPTION
This fixes the test case that is causing all PRs to fail the test case check.

It also includes some changes to the HORIZONS code for immutability, and makes `HorizonsAngle`, the convenience collection of angle transformations that are static, an uninstantiable class.

More importantly, it also adds a `Coordinates` generator for hypothesis. The former generation was generating values in degrees when `Coordinates` and the many methods it calls require the units to be in radians.