### PR TITLE
SCHED-351: Ranker modifications

### DIFF
--- a/scheduler/core/calculations/programinfo.py
+++ b/scheduler/core/calculations/programinfo.py
@@ -40,6 +40,7 @@ class ProgramInfo:
         object.__setattr__(self, 'observation_ids', frozenset(self.observations.keys()))
         object.__setattr__(self, 'group_ids', frozenset(self.group_data_map.keys()))
 
+
 @dataclass(frozen=True)
 class ProgramCalculations:
     """

--- a/scheduler/core/components/ranker/base.py
+++ b/scheduler/core/components/ranker/base.py
@@ -24,12 +24,22 @@ class Ranker:
         self.night_indices = night_indices
         self.sites = sites
 
-        # Create a full zero score that fits the sites, nights, and time slots for initialization
-        # and to return if an observation is not to be included.
-        self._zero_scores: Dict[Site, List[npt.NDArray[float]]] = {}
+        # For convenience, for each site, create:
+        # 1. An empty observation score array.
+        # 2. An empty group scoring array, used to collect the group scores.
+        self._empty_obs_scores: Dict[Site, List[npt.NDArray[float]]] = {}
+        self._empty_group_scores: Dict[Site, List[npt.NDArray[float]]] = {}
         for site in self.collector.sites:
             night_events = self.collector.get_night_events(site)
-            self._zero_scores[site] = [np.zeros(len(night_events.times[night_idx])) for night_idx in self.night_indices]
+
+            # Create a full zero score that fits the sites, nights, and time slots for observations.
+            self._empty_obs_scores[site] = [np.zeros(len(night_events.times[night_idx]), dtype=float)
+                                            for night_idx in self.night_indices]
+
+            # Create a full zero score that fits the sites, nights, and time slots for group calculations.
+            # As this must collect the subgroups, the dimensions are different from observation scores.
+            self._empty_group_scores[site] = [np.zeros((0, len(night_events.times[night_idx])), dtype=float)
+                                              for night_idx in self.night_indices]
 
     def score_group(self, group: Group, group_data_map: GroupDataMap) -> Scores:
         """

--- a/scheduler/core/components/ranker/default.py
+++ b/scheduler/core/components/ranker/default.py
@@ -171,7 +171,7 @@ class DefaultRanker(Ranker):
 
         return metric, metric_slope
 
-    def _score_obs(self, program: Program, obs: Observation) -> Scores:
+    def score_observation(self, program: Program, obs: Observation) -> Scores:
         """
         Calculate the scores for an observation for each night for each time slot index.
         These are returned as a list indexed by night index as per the night_indices supplied,
@@ -235,7 +235,7 @@ class DefaultRanker(Ranker):
         for night_idx in self.night_indices:
             slot_indices = target_info[night_idx].visibility_slot_idx
             scores[night_idx].put(slot_indices, p[night_idx][slot_indices])
-        print(f'   max score: {np.max(scores[0])}')
+            print(f'   max score on night {night_idx}: {np.max(scores[night_idx])}')
 
         return scores
 

--- a/scheduler/core/components/ranker/default.py
+++ b/scheduler/core/components/ranker/default.py
@@ -179,7 +179,7 @@ class DefaultRanker(Ranker):
         """
         # Scores are indexed by night_idx and contain scores for each time slot.
         # We initialize to all zeros.
-        scores = deepcopy(self._zero_scores[obs.site])
+        scores = deepcopy(self._empty_obs_scores[obs.site])
 
         # target_info is a map from night index to TargetInfo.
         # We require it to proceed for hour angle / elevation information and coordinates.
@@ -252,9 +252,7 @@ class DefaultRanker(Ranker):
 
         # Determine the length of the nights and create an empty score array for each night.
         site = list(group.sites())[0]
-        night_events = self.collector.get_night_events(site)
-        group_scores = [np.empty((0, len(night_events.times[night_idx])), dtype=float)
-                        for night_idx in self.night_indices]
+        scores = deepcopy(self._empty_group_scores[site])
 
         # For each night, calculate the score for the group over its subgroups.
         # This may not be the same as using the observation scoring, since for groups, the score has been adjusted in
@@ -266,11 +264,11 @@ class DefaultRanker(Ranker):
                 # To get this, we turn the scores of the children into a (1, #timeslots in night) array to append
                 # to the numpy array for the night.
                 subgroup_scores = np.array([group_data_map[unique_group_id].group_info.scores[night_idx]])
-                group_scores[night_idx] = np.append(group_scores[night_idx], subgroup_scores, axis=0)
+                scores[night_idx] = np.append(scores[night_idx], subgroup_scores, axis=0)
 
         # Combine the scores as per the score_combiner and return.
         # apply_along_axis results in a (1, #timeslots in night) array, so we have to take index 0.
-        return [np.apply_along_axis(self.params.score_combiner, 0, group_scores[night_idx])[0]
+        return [np.apply_along_axis(self.params.score_combiner, 0, scores[night_idx])[0]
                 for night_idx in self.night_indices]
 
     def _score_or_group(self, group: OrGroup, group_data_map: GroupDataMap) -> Scores:


### PR DESCRIPTION
The `Ranker` should not be scoring all `Observation`s across all `Program`s upon creation.

Since we may create several `Ranker`s simply out of convenience (we should decide if the `Ranker` is owned by anything, e.g. possibly the `Selector`), and in subsequent scoring of `Program`s after `Observation`s or `Atom`s are executed, we do not want to use the `Collector`'s cache of `Program`s, but the modified `Program`s after GreedyMax produces a `Plan` and part of it is executed.

Formerly as well, `Observation`s that belong to observation groups were being scored, but the scoring was useless since we were lacking some information necessary to score the observation group containing the `Observation`, such as the `Conditions` / `Constraints` (see GN-2018B-Q-101-1460 and GN-2018B-Q-101-1462 in the OT for examples).

Now, the former `_score_obs` method that scored an `Observation` in the constructor for `Ranker` has been renamed to `score_observation` and is only called in the `Selector` when scoring an observation group, so observation groups missing components will not waste resources scoring their observations when they cannot even be themselves scored.

The initial `Ranker` scoring has been eliminated. All we do now is create empty arrays to be used for scoring as a convenience and so we do not have to store a reference to the `Collector` in the `Ranker`, which is unnecessary.