### PR TITLE
SCHED-362: Ability to re-score programs from the Selection

### DIFF
--- a/scheduler/core/calculations/selection.py
+++ b/scheduler/core/calculations/selection.py
@@ -3,11 +3,13 @@
 
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import FrozenSet, Mapping
+from typing import FrozenSet, Mapping, Optional
 
 from lucupy.helpers import flatten
-from lucupy.minimodel import Group, ProgramID, Site, UniqueGroupID
+from lucupy.minimodel import Group, NightIndices, Program, ProgramID, Site, UniqueGroupID
 
+from ..components.ranker import Ranker
+from ..components.selector import Selector
 from .groupinfo import GroupData
 from .nightevents import NightEvents
 from .programinfo import ProgramInfo
@@ -24,6 +26,9 @@ class Selection:
     night_events: Mapping[Site, NightEvents]
     num_nights: int
     time_slot_length: timedelta
+
+    # Reference to
+    _selector: Selector
 
     @property
     def sites(self) -> FrozenSet[Site]:
@@ -52,3 +57,9 @@ class Selection:
         ))
         object.__setattr__(self, 'obs_group_ids', obs_group_ids)
         object.__setattr__(self, 'obs_group_id_list', list(sorted(obs_group_ids)))
+
+    def score_program(self,
+                      program: Program,
+                      sites: Optional[FrozenSet[Site]] = sites,
+                      night_indices: Optional[NightIndices] = None,
+                      ranker: Optional[Ranker] = None):

--- a/scheduler/core/calculations/selection.py
+++ b/scheduler/core/calculations/selection.py
@@ -8,7 +8,7 @@ from typing import Callable, FrozenSet, Mapping, Optional
 from lucupy.helpers import flatten
 from lucupy.minimodel import Group, NightIndices, Program, ProgramID, Site, UniqueGroupID
 
-from ..components.ranker import Ranker
+# from ..components.ranker import Ranker
 from .groupinfo import GroupData
 from .nightevents import NightEvents
 from .programinfo import ProgramCalculations, ProgramInfo
@@ -25,14 +25,14 @@ class Selection:
     night_events: Mapping[Site, NightEvents]
     num_nights: int
     time_slot_length: timedelta
-    _program_scorer: Callable[[Program, Optional[FrozenSet[Site]], Optional[NightIndices], Optional[Ranker]],
+    _program_scorer: Callable[[Program, Optional[FrozenSet[Site]], Optional[NightIndices], Optional['Ranker']],
                               Optional[ProgramCalculations]]
 
     def score_program(self,
                       program: Program,
                       sites: Optional[FrozenSet[Site]] = None,
                       night_indices: Optional[NightIndices] = None,
-                      ranker: Optional[Ranker] = None):
+                      ranker: Optional['Ranker'] = None):
         return self._program_scorer(program, sites, night_indices, ranker)
 
     @property

--- a/scheduler/core/components/selector/__init__.py
+++ b/scheduler/core/components/selector/__init__.py
@@ -131,7 +131,8 @@ class Selector(SchedulerComponent):
             schedulable_groups=schedulable_groups_map,
             night_events={site: self.collector.get_night_events(site) for site in sites},
             num_nights=len(self.collector.time_grid),
-            time_slot_length=self.collector.time_slot_length.to_datetime()
+            time_slot_length=self.collector.time_slot_length.to_datetime(),
+            _program_scorer=self.score_program
         )
 
     def score_program(self,

--- a/scheduler/scripts/check_headers.py
+++ b/scheduler/scripts/check_headers.py
@@ -7,8 +7,9 @@ from definitions import ROOT_DIR
 
 # Checks the headers of all .py files to make sure that they contain the above Copyright message.
 
+HEADER = ('# Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)\n'
+          '# For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause')
 
-HEADER = '# Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)\n# For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause'
 
 def pre_adder(file):
     with open(file, 'r+') as f:

--- a/scheduler/scripts/run_scheduler.py
+++ b/scheduler/scripts/run_scheduler.py
@@ -162,9 +162,14 @@ if __name__ == '__main__':
     plans = optimizer.schedule()
     print_plans(plans)
 
+    # Example for Bryan:
     # Re-run the Selection score_program method.
+    # The Selection has a score_program method (which can take a variety of parameters, but most can be left as None)
+    # and returns a ProgramCalculations object, which is the data used by the Selector to populate arrays and create
+    # the initial selection. Here, we go over the top-level groups in the ProgramCalculations for the Program we have
+    # re-scored, and print the max score per night for each group.
     print()
-    for program_id, program_info in selection.program_info:
+    for program_id, program_info in selection.program_info.items():
         print(f'*** RE-SCORING {program_id} ***')
         program = program_info.program
         program_calculations = selection.score_program(program)

--- a/scheduler/scripts/run_scheduler.py
+++ b/scheduler/scripts/run_scheduler.py
@@ -162,4 +162,16 @@ if __name__ == '__main__':
     plans = optimizer.schedule()
     print_plans(plans)
 
+    # Re-run the Selection score_program method.
+    print()
+    for program_id, program_info in selection.program_info:
+        print(f'*** RE-SCORING {program_id} ***')
+        program = program_info.program
+        program_calculations = selection.score_program(program)
+        for unique_group_id in program_calculations.top_level_groups:
+            group_data = program_calculations.group_data_map[unique_group_id]
+            group, group_info = group_data
+            max_scores_per_night = [max(score) for score in group_info.scores]
+            print(f'For {unique_group_id}, max scores are: {max_scores_per_night}')
+
     print('DONE')


### PR DESCRIPTION
This adds a method to the `Selection` that allows the re-scoring of `Program`s. This simply defers to the `Selector` but without revealing the entire `Selector` to the `Selection`.

A call to rescore a program results in a `ProgramCalculation`, which contains all the data used by the `Selector` to assemble the `Selection`.