### PR TITLE
SCHED-451: Cleanup and fixing test cases

### DIFF
--- a/scheduler/core/calculations/groupinfo.py
+++ b/scheduler/core/calculations/groupinfo.py
@@ -28,8 +28,6 @@ class GroupInfo:
     6. Scoring based on how the wind affects the group.
     7. A list of indices of the time slots across the nights as to when the group can be scheduled.
     8. The score assigned to the group.
-
-    A group can be split if and only if it contains more than one observation.
     """
     minimum_conditions: Conditions
     is_splittable: bool

--- a/scheduler/core/components/optimizer/greedymax.py
+++ b/scheduler/core/components/optimizer/greedymax.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from enum import Enum
 from typing import final, Dict, FrozenSet, List, Optional, Tuple
 
 import matplotlib.pyplot as plt

--- a/scheduler/core/programprovider/ocs/__init__.py
+++ b/scheduler/core/programprovider/ocs/__init__.py
@@ -663,8 +663,10 @@ class OcsProgramProvider(ProgramProvider):
         # TODO: For now, we focus on instruments, and GMOS FPUs and dispersers exclusively.
         instrument_resources = frozenset([self._sources.origin.resource.lookup_resource(instrument)])
         if 'GMOS' in instrument:
-            # Convert FPUs and dispersers to barcodes.
-            fpu_resources = frozenset([self._sources.origin.resource.fpu_to_barcode(site, fpu, instrument) for fpu in fpus])
+            # Convert FPUs and dispersers to barcodes. Note that None might be contained in some of these
+            # sets, but we filter below to remove them.
+            fpu_resources = frozenset([self._sources.origin.resource.fpu_to_barcode(site, fpu, instrument)
+                                       for fpu in fpus])
             disperser_resources = frozenset([self._sources.origin.resource.lookup_resource(disperser.split('_')[0])
                                              for disperser in dispersers])
             resources = frozenset([r for r in fpu_resources | disperser_resources | instrument_resources])

--- a/scheduler/services/resource/base.py
+++ b/scheduler/services/resource/base.py
@@ -112,7 +112,7 @@ class ResourceService(ExternalService):
         if inst in ResourceService._instd.keys():
             # Collect the components of the string from the MDF name.
             inst_id = ResourceService._instd[inst]
-            sem_id = ResourceService._instd[mdfname[6]]
+            sem_id = ResourceService._semd[mdfname[6]]
             progtype_id = ResourceService._progd[mdfname[7]]
             barcode = f'{inst_id}{sem_id}{progtype_id}{mdfname[-6:-3]}{mdfname[-2:]}'
         return self.lookup_resource(barcode)

--- a/tests/unit/scheduler/core/programprovider/ocs/test_ocs_api.py
+++ b/tests/unit/scheduler/core/programprovider/ocs/test_ocs_api.py
@@ -8,10 +8,10 @@ from datetime import datetime, timedelta
 from lucupy.helpers import dmsstr2deg
 from lucupy.minimodel import (AndGroup, AndOption, Atom, Band, CloudCover, Conditions, Constraints, ElevationType,
                               GroupID, ImageQuality, Magnitude, MagnitudeBands, ObservationClass, ObservationID,
-                              ObservationStatus, Priority, Program, ProgramID, ProgramMode, ProgramTypes, QAState,
-                              Resource, ROOT_GROUP_ID, Semester, SemesterHalf, SetupTimeType, SiderealTarget, Site,
-                              SkyBackground, TargetName, TargetType, TimeAccountingCode, TimeAllocation, TimingWindow,
-                              TooType, WaterVapor, Wavelength)
+                              ObservationMode, ObservationStatus, Priority, Program, ProgramID, ProgramMode,
+                              ProgramTypes, QAState, Resource, ROOT_GROUP_ID, Semester, SemesterHalf, SetupTimeType,
+                              SiderealTarget, Site, SkyBackground, TargetName, TargetType, TimeAccountingCode,
+                              TimeAllocation, TimingWindow, TooType, WaterVapor, Wavelength)
 from lucupy.observatory.gemini.geminiobservation import GeminiObservation
 from lucupy.timeutils import sex2dec
 
@@ -118,7 +118,8 @@ def create_minimodel_program() -> Program:
             qa_state=QAState.NONE,
             guide_state=True,
             resources=frozenset({gmosn, mirror}),
-            wavelengths=frozenset({Wavelength(0.475)})
+            wavelengths=frozenset({Wavelength(0.475)}),
+            obs_mode=ObservationMode.IMAGING
         )
     ]
 
@@ -232,7 +233,8 @@ def create_minimodel_program() -> Program:
             qa_state=QAState.NONE,
             guide_state=True,
             resources=frozenset({gnirs}),
-            wavelengths=frozenset({Wavelength(2.2)})
+            wavelengths=frozenset({Wavelength(2.2)}),
+            obs_mode=ObservationMode.IMAGING
         )
     ]
 
@@ -351,7 +353,8 @@ def create_minimodel_program() -> Program:
             qa_state=QAState.NONE,
             guide_state=True,
             resources=frozenset({gnirs}),
-            wavelengths=frozenset({Wavelength(2.2)})
+            wavelengths=frozenset({Wavelength(2.2)}),
+            obs_mode=ObservationMode.IMAGING
         )
     ]
 
@@ -526,7 +529,8 @@ def create_minimodel_program() -> Program:
             qa_state=QAState.NONE,
             guide_state=True,
             resources=frozenset({gmosn, mirror}),
-            wavelengths=frozenset({Wavelength(0.475)})
+            wavelengths=frozenset({Wavelength(0.475)}),
+            obs_mode=ObservationMode.IMAGING
         )
     ]
 


### PR DESCRIPTION
Some minor improvements and cleanup to:

1. Move magic values out of a method.
2. Use f-strings to create a barcode.
3. `ResourceService._mdf_to_barcode` now properly reuses cached `Resource`s that have already been created instead of making duplicates of existing ones.

This also fixes a test case that broke as a result of the addition of the `obs_mode: ObservationMode` field to `Atom` in lucupy.