### PR TITLE
SCHED-454: Fixed issue where illegal numpy broadcasts were being done.

### DIFF
--- a/demo/try_scheduler.ipynb
+++ b/demo/try_scheduler.ipynb
@@ -32,6 +32,7 @@
     "import pandas as pd\n",
     "from IPython.display import display\n",
     "\n",
+    "from astropy.time import Time\n",
     "from lucupy.minimodel.constraints import CloudCover, ImageQuality\n",
     "from lucupy.minimodel.semester import SemesterHalf\n",
     "from lucupy.minimodel.site import Site\n",

--- a/scheduler/core/components/collector/__init__.py
+++ b/scheduler/core/components/collector/__init__.py
@@ -412,6 +412,10 @@ class Collector(SchedulerComponent):
         The json_data comprises the program inputs as an iterable object per site. We use iterable
         since the amount of data here might be enormous, and we do not want to store it all
         in memory at once.
+
+        As this is OCS-specific, in a Program, all observations are guaranteed to be at the same site;
+        however, since this may not always be the case and will not in GPP, we still process all programs
+        and simply omit observations that are not at a site listed in the desired sites.
         """
         if not (isclass(program_provider_class) and issubclass(program_provider_class, ProgramProvider)):
             raise ValueError('Collector load_programs requires a ProgramProvider class as the second argument')

--- a/scheduler/core/components/selector/__init__.py
+++ b/scheduler/core/components/selector/__init__.py
@@ -57,7 +57,7 @@ class Selector(SchedulerComponent):
                              'Cannot proceed.')
 
     def select(self,
-               sites: FrozenSet[Site] = ALL_SITES,
+               sites: Optional[FrozenSet[Site]] = None,
                night_indices: Optional[NightIndices] = None,
                ranker: Optional[Ranker] = None) -> Selection:
         """
@@ -79,6 +79,11 @@ class Selector(SchedulerComponent):
 
         An AND group must be able to perform all of its children.
         """
+        if sites is None:
+            sites = self.collector.sites
+        if not sites:
+            raise ValueError('Attempted to fetch a selection over no sites.')
+
         # NOTE: If night_indices is None, assume the whole calculation period.
         if night_indices is None:
             night_indices = np.arange(len(self.collector.time_grid))
@@ -265,8 +270,10 @@ class Selector(SchedulerComponent):
         if obs.status not in {ObservationStatus.ONGOING, ObservationStatus.READY}:
             logger.warning(f'Selector skipping observation {obs.id}: status is {obs.status.name}.')
             return group_data_map
+
+        # This should never happen.
         if obs.site not in sites:
-            logger.warning(f'Selector skipping observation {obs.id}: not at a designated site.')
+            logger.error(f'Selector requested to score {obs.id}: not at a designated site.')
             return group_data_map
 
         # We ignore the Observation if:
@@ -315,7 +322,7 @@ class Selector(SchedulerComponent):
             start_time = night_events.times[night_idx][0]
             end_time = night_events.times[night_idx][-1]
             actual_conditions = self.collector.sources.origin.env.get_actual_conditions_variant(obs.site,
-                                                                                                    start_time,
+                                                                                                start_time,
                                                                                                 end_time)
             actual_conditions = Variant(iq=np.array([self.default_cc for i in range(len(actual_conditions.cc))]),
                                         cc=np.array([self.default_iq for i in range(len(actual_conditions.cc))]),
@@ -402,6 +409,12 @@ class Selector(SchedulerComponent):
         # Ignore the return values here: they will just accumulate in group_info_map.
         for subgroup in group.children:
             self._calculate_group(program, subgroup, sites, night_indices, night_configurations, ranker, group_data_map)
+
+        # We can only schedule this group if its sites are all being scheduled; however, we still want to
+        # score this group's children if their sites are covered: hence the check after the child scoring.
+        if not group.sites().issubset(sites):
+            logger.warning(f'Cannot score group {group.id}: contains observations in sites not being scheduled.')
+            return group_data_map
 
         # TODO: Confirm that this is correct behavior.
         # Make sure that there is an entry for each subgroup. If not, we skip.

--- a/scheduler/core/components/selector/__init__.py
+++ b/scheduler/core/components/selector/__init__.py
@@ -155,6 +155,7 @@ class Selector(SchedulerComponent):
         If the sites used by the Program do not intersect the sites parameter, then None is returned.
         Otherwise, the data is bundled in a ProgramCalculations object.
         """
+        # TODO: We may want to change this to handle sites like with select, i.e. use the Collector's sites.
         # If sites are specified and this program is not in the specified sites, issue a warning and return None.
         if sites is not None and len(sites.intersection(program.root_group.sites())) == 0:
             logger.warning(f'Attempt to score program {program.id}, but program is not at site specified for scoring.')

--- a/scheduler/scripts/run_greedymax.py
+++ b/scheduler/scripts/run_greedymax.py
@@ -33,9 +33,12 @@ if __name__ == '__main__':
         1.0
     )
 
+    start = Time("2018-10-01 08:00:00", format='iso', scale='utc')
+    end = Time("2018-10-03 08:00:00", format='iso', scale='utc')
+    num_nights_to_schedule = int(round(end.jd - start.jd)) + 1
     collector = SchedulerBuilder.build_collector(
-        start=Time("2018-10-01 08:00:00", format='iso', scale='utc'),
-        end=Time("2018-10-03 08:00:00", format='iso', scale='utc'),
+        start=start,
+        end=end,
         sites=ALL_SITES,
         semesters=frozenset([Semester(2018, SemesterHalf.B)]),
         blueprint=collector_blueprint
@@ -65,7 +68,7 @@ if __name__ == '__main__':
     # IQ values are IQ20, IQ70, IQ85, and IQANY. Default is IQ70 if not passed to build_selector.
     iq = ImageQuality.IQ70
     selector = SchedulerBuilder.build_selector(collector,
-                                               num_nights_to_schedule=3,
+                                               num_nights_to_schedule=num_nights_to_schedule,
                                                default_cc=cc,
                                                default_iq=iq)
 

--- a/scheduler/scripts/run_greedymax_twice.py
+++ b/scheduler/scripts/run_greedymax_twice.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+# For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+# NOTE: This is for testing purposes.
+# An error was detected when trying to schedule a single site: Selector.select was still scoring
+# observations for both sites. This tests the functionality to make sure that it now works correctly
+# without having to go through any UI such as mercury.
+
+import os
+import logging
+
+from lucupy.minimodel.constraints import CloudCover, ImageQuality
+from lucupy.minimodel.site import ALL_SITES
+from lucupy.minimodel.semester import SemesterHalf
+from lucupy.observatory.abstract import ObservatoryProperties
+from lucupy.observatory.gemini import GeminiProperties
+
+from definitions import ROOT_DIR
+from scheduler.core.builder.blueprint import CollectorBlueprint, OptimizerBlueprint
+from scheduler.core.builder.builder import SchedulerBuilder
+from scheduler.core.components.collector import *
+from scheduler.core.output import print_collector_info, print_plans
+from scheduler.core.programprovider.ocs import read_ocs_zipfile, OcsProgramProvider
+from scheduler.services import logger_factory
+
+
+if __name__ == '__main__':
+    logger = logger_factory.create_logger(__name__, logging.INFO)
+    ObservatoryProperties.set_properties(GeminiProperties)
+
+    print('***** RUN 1 *****')
+    # Read in a list of JSON data
+    programs = read_ocs_zipfile(os.path.join(ROOT_DIR, 'scheduler', 'data', '2018B_program_samples.zip'))
+
+    # Create the Collector and load the programs.
+    collector_blueprint = CollectorBlueprint(
+        ['SCIENCE', 'PROGCAL', 'PARTNERCAL'],
+        ['Q', 'LP', 'FT', 'DD'],
+        1.0
+    )
+
+    start = Time("2018-10-01 08:00:00", format='iso', scale='utc')
+    end = Time("2018-10-03 08:00:00", format='iso', scale='utc')
+    num_nights_to_schedule = int(round(end.jd - start.jd)) + 1
+    collector = SchedulerBuilder.build_collector(
+        start=start,
+        end=end,
+        sites=ALL_SITES,
+        semesters=frozenset([Semester(2018, SemesterHalf.B)]),
+        blueprint=collector_blueprint
+    )
+    collector.load_programs(program_provider_class=OcsProgramProvider,
+                            data=programs)
+    print_collector_info(collector, samples=60)
+
+    cc = CloudCover.CC50
+    iq = ImageQuality.IQ70
+    selector = SchedulerBuilder.build_selector(collector,
+                                               num_nights_to_schedule=num_nights_to_schedule,
+                                               default_cc=cc,
+                                               default_iq=iq)
+
+    # Prepare the optimizer.
+    optimizer_blueprint = OptimizerBlueprint(
+        "GreedyMax"
+    )
+    optimizer = SchedulerBuilder.build_optimizer(
+        blueprint=optimizer_blueprint
+    )
+
+    # The total nights for which visibility calculations have been done.
+    total_nights = len(collector.time_grid)
+
+    # Create the overall plans by night.
+    overall_plans = {}
+    for night_idx in range(selector.num_nights_to_schedule):
+        # Get the night indices for which we are selecting.
+        # TODO: We will want scores for nights to look ahead for greedy optimization.
+        # TODO: For now, we use the entire period for which visibility calculations have been done.
+        # night_indices = range(night_idx, total_nights)
+        night_indices = np.array([night_idx])
+        # selection = selector.select(night_indices=np.array([0, 1, 2])
+        selection = selector.select(night_indices=night_indices)
+
+        # Run the optimizer to get the plans for the first night in the selection.
+        plans = optimizer.schedule(selection)
+        night_plans = plans[0]
+
+        # Store the plans in the overall_plans array for that night.
+        # TODO: This might be an issue. We may need to index nights (plans) in optimizer by night_idx.
+        overall_plans[night_idx] = night_plans
+
+        # Perform the time accounting on the plans.
+        collector.time_accounting(night_plans)
+
+    overall_plans = [p for _, p in sorted(overall_plans.items())]
+    print_plans(overall_plans)
+
+    print('\n\n\n***** RUN 2 *****')
+    # Read in a list of JSON data
+    programs = read_ocs_zipfile(os.path.join(ROOT_DIR, 'scheduler', 'data', '2018B_program_samples.zip'))
+
+    # Create the Collector and load the programs.
+    collector_blueprint = CollectorBlueprint(
+        ['SCIENCE', 'PROGCAL', 'PARTNERCAL'],
+        ['Q', 'LP', 'FT', 'DD'],
+        1.0
+    )
+
+    start = Time("2018-10-04 08:00:00", format='iso', scale='utc')
+    end = Time("2018-10-07 08:00:00", format='iso', scale='utc')
+    num_nights_to_schedule = int(round(end.jd - start.jd)) + 1
+    collector = SchedulerBuilder.build_collector(
+        start=start,
+        end=end,
+        sites=frozenset({Site.GS}),
+        semesters=frozenset([Semester(2018, SemesterHalf.B)]),
+        blueprint=collector_blueprint
+    )
+    collector.load_programs(program_provider_class=OcsProgramProvider,
+                            data=programs)
+    print_collector_info(collector, samples=60)
+
+    cc = CloudCover.CC50
+    iq = ImageQuality.IQ70
+    selector = SchedulerBuilder.build_selector(collector,
+                                               num_nights_to_schedule=num_nights_to_schedule,
+                                               default_cc=cc,
+                                               default_iq=iq)
+
+    # Prepare the optimizer.
+    optimizer_blueprint = OptimizerBlueprint(
+        "GreedyMax"
+    )
+    optimizer = SchedulerBuilder.build_optimizer(
+        blueprint=optimizer_blueprint
+    )
+
+    # The total nights for which visibility calculations have been done.
+    total_nights = len(collector.time_grid)
+
+    # Create the overall plans by night.
+    overall_plans = {}
+    for night_idx in range(selector.num_nights_to_schedule):
+        # Get the night indices for which we are selecting.
+        # TODO: We will want scores for nights to look ahead for greedy optimization.
+        # TODO: For now, we use the entire period for which visibility calculations have been done.
+        # night_indices = range(night_idx, total_nights)
+        night_indices = np.array([night_idx])
+        # selection = selector.select(night_indices=np.array([0, 1, 2])
+        selection = selector.select(night_indices=night_indices)
+
+        # Run the optimizer to get the plans for the first night in the selection.
+        plans = optimizer.schedule(selection)
+        night_plans = plans[0]
+
+        # Store the plans in the overall_plans array for that night.
+        # TODO: This might be an issue. We may need to index nights (plans) in optimizer by night_idx.
+        overall_plans[night_idx] = night_plans
+
+        # Perform the time accounting on the plans.
+        collector.time_accounting(night_plans)
+
+    overall_plans = [p for _, p in sorted(overall_plans.items())]
+    print_plans(overall_plans)
+
+    print('DONE')


### PR DESCRIPTION
It turns out that in the `Selector.selection` method, `ALL_SITES` was always being used, which was causing errors since if only one site was given to the `Collector` unless the `NightEvent` information for the nights desired had already been computed and cached in `NightEventsManager`, we had observations being evaluated using information that didn't exist in `NightEventsManager` against env data, which generated numpy broadcast errors in the size of arrays.

Note that this also adds a script that can be run to test to make sure things work now (`run_greedymax_twice.py`) so as to run the same scenario that was originally discovered by German in Mercury without all the additional noise Mercury generates.

There is also some error-handling code added, and the scripts `run_greedymax.py` and `run_greedymax_twice.py` now both properly calculate the `num_nights_to_schedule` programmatically from the start and the end of the scheduling period instead of using a fixed value.

Finally, in the Mercury notebook, I added an import for `astropy` `Time`, since there was a crash where it couldn't find the definition.