### PR TITLE
SCHED-463: Fixed NightEventManager caching.

### DIFF
--- a/scheduler/core/components/nighteventsmanager/__init__.py
+++ b/scheduler/core/components/nighteventsmanager/__init__.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-import time
 from typing import Dict, Tuple
 
 from astropy.time import Time, TimeDelta
@@ -27,11 +26,10 @@ class NightEventsManager(metaclass=Singleton):
         Retrieve NightEvents. These may contain more information than requested,
         but never less.
         """
-        start = time.perf_counter()
         # The identifier used for caching.
         data_id = (site, time_slot_length.jd, time_grid[0].jd, time_grid[-1].jd)
 
-        # Recalculate if we are not compatible.
+        # Recalculate if necessary.
         if data_id not in NightEventsManager._night_events:
             night_events = NightEvents(
                 time_grid,
@@ -40,8 +38,5 @@ class NightEventsManager(metaclass=Singleton):
                 *sky.night_events(time_grid, site.location, site.timezone)
             )
             NightEventsManager._night_events[data_id] = night_events
-
-        end = time.perf_counter()
-        print(f"*** get_night_events took {end - start:.8f} seconds")
 
         return NightEventsManager._night_events[data_id]

--- a/scheduler/core/components/nighteventsmanager/__init__.py
+++ b/scheduler/core/components/nighteventsmanager/__init__.py
@@ -15,8 +15,8 @@ class NightEventsManager(metaclass=Singleton):
     """
     A singleton class that manages pre-calculations of NightEvents for each Site during the dates specified.
     """
-    _data_id = Tuple[Site, TimeDelta, Time, Time]
-    _night_events: Dict[_data_id, NightEvents] = {}
+    _ID = Tuple[Site, TimeDelta, Time, Time]
+    _night_events: Dict[_ID, NightEvents] = {}
 
     @staticmethod
     def get_night_events(time_grid: Time,
@@ -27,7 +27,7 @@ class NightEventsManager(metaclass=Singleton):
         but never less.
         """
         # The identifier used for caching.
-        data_id = (site, time_slot_length.jd, time_grid[0].jd, time_grid[-1].jd)
+        data_id: NightEventsManager._ID = (site, time_slot_length, time_grid[0], time_grid[-1])
 
         # Recalculate if necessary.
         if data_id not in NightEventsManager._night_events:

--- a/scheduler/scripts/run_greedymax_twice.py
+++ b/scheduler/scripts/run_greedymax_twice.py
@@ -40,8 +40,10 @@ if __name__ == '__main__':
     )
     builder = ValidationBuilder(Sources())
 
+    # start = Time("2018-10-01 08:00:00", format='iso', scale='utc')
+    # end = Time("2018-10-03 08:00:00", format='iso', scale='utc')
     start = Time("2018-10-01 08:00:00", format='iso', scale='utc')
-    end = Time("2018-10-03 08:00:00", format='iso', scale='utc')
+    end = Time("2018-10-05 08:00:00", format='iso', scale='utc')
     num_nights_to_schedule = int(round(end.jd - start.jd)) + 1
     collector = builder.build_collector(
         start=start,
@@ -110,8 +112,10 @@ if __name__ == '__main__':
     )
     builder = ValidationBuilder(Sources())
 
-    start = Time("2018-10-04 08:00:00", format='iso', scale='utc')
-    end = Time("2018-10-07 08:00:00", format='iso', scale='utc')
+    # start = Time("2018-10-04 08:00:00", format='iso', scale='utc')
+    # end = Time("2018-10-07 08:00:00", format='iso', scale='utc')
+    start = Time("2018-10-02 08:00:00", format='iso', scale='utc')
+    end = Time("2018-10-04 08:00:00", format='iso', scale='utc')
     num_nights_to_schedule = int(round(end.jd - start.jd)) + 1
     collector = builder.build_collector(
         start=start,


### PR DESCRIPTION
The former caching was not working correctly.

The actual `NightEvents` calculations are quite quick, at less than one second a day on my local machine, but they are requested many times, leading to timing issues.

Now, instead of trying to reuse parts of dates already calculated and cached, we simply create an ID for the current request (which may overlap or even be a subset of previous requests), calculate that, and cache that.

This is far simpler because the `NightEvents` for multiple nights are stored in a single `NightEvents` object, so to manage multiple `NightEvents` objects and then extract and merge parts of them is very difficult. Given the low calculation time, this does not seem necessary.