### PR TITLE
Quick fix to avoid referencing past the end of the list

### DIFF
--- a/scheduler/core/components/optimizer/greedymax.py
+++ b/scheduler/core/components/optimizer/greedymax.py
@@ -117,7 +117,7 @@ class GreedyMaxOptimizer(BaseOptimizer):
         """
         idx = 0
         value = inlist[idx]
-        while value == ZeroTime:
+        while value == ZeroTime and idx < len(inlist) - 1:
             idx += 1
             value = inlist[idx]
         return idx


### PR DESCRIPTION
This avoids a crash but we need to investigate why it was getting to this state (selector issue?) and may need to add other error checks.
