### PR TITLE
GSCHED-482: Modify scoring algorithms to allow for partial night scoring.

### DIFF
--- a/scheduler/core/calculations/selection.py
+++ b/scheduler/core/calculations/selection.py
@@ -8,10 +8,9 @@ from typing import Callable, FrozenSet, Mapping, Optional
 from lucupy.helpers import flatten
 from lucupy.minimodel import Group, NightIndices, Program, ProgramID, Site, UniqueGroupID
 
-from ..components.ranker import Ranker
-from .groupinfo import GroupData
-from .nightevents import NightEvents
-from .programinfo import ProgramCalculations, ProgramInfo
+from scheduler.core.components.ranker import Ranker
+from scheduler.core.types import StartingTimeSlots
+from scheduler.core.calculations import GroupData, NightEvents, ProgramCalculations, ProgramInfo
 
 
 @dataclass(frozen=True)
@@ -31,7 +30,11 @@ class Selection:
     time_slot_length: timedelta
 
     # Used to re-score programs.
-    _program_scorer: Optional[Callable[[Program, Optional[FrozenSet[Site]], Optional[NightIndices], Optional[Ranker]],
+    _program_scorer: Optional[Callable[[Program,
+                                        Optional[FrozenSet[Site]],
+                                        Optional[NightIndices],
+                                        Optional[Ranker],
+                                        Optional[StartingTimeSlots]],
                               Optional[ProgramCalculations]]] = field(default=None)
 
     def __reduce__(self):
@@ -48,6 +51,7 @@ class Selection:
                       program: Program,
                       sites: Optional[FrozenSet[Site]] = None,
                       night_indices: Optional[NightIndices] = None,
+                      starting_time_slots: Optional[StartingTimeSlots] = None,
                       ranker: Optional[Ranker] = None) -> ProgramCalculations:
         """
         Re-score a program. This calls Selector.score_program, which checks to make sure
@@ -61,7 +65,7 @@ class Selection:
 
         if night_indices is None:
             night_indices = self.night_indices
-        return self._program_scorer(program, sites, night_indices, ranker)
+        return self._program_scorer(program, sites, night_indices, starting_time_slots, ranker)
 
     @property
     def sites(self) -> FrozenSet[Site]:

--- a/scheduler/core/types/__init__.py
+++ b/scheduler/core/types/__init__.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+# For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+from typing import Dict
+
+from lucupy.minimodel import NightIndex, TimeslotIndex
+
+# Alias for map from night index to time slot on which to start scoring a group or observation.
+# The scores for all time slots prior to the night's time slot will be set to zero to allow for partial night scoring.
+# Cannot include in Selector since this introduces a circular dependency.
+StartingTimeSlots = Dict[NightIndex, TimeslotIndex]
+


### PR DESCRIPTION
Now we allow a map to be specified from `NightIndex` to `TimeslotIndex` that zeroes out the scores prior to the specified `TimeslotIndex` for the night to allow for partial scoring.

Anything with a score of 0 should not be scheduled, so this allows us to in essence say that we have scored up to that point in the night and subsequent plans should be empty for that portion of the night.