### PR TITLE
SCHED-428B: Fixes and restructuring for starting time slots.

### DIFF
--- a/scheduler/core/calculations/selection.py
+++ b/scheduler/core/calculations/selection.py
@@ -28,13 +28,15 @@ class Selection:
     night_events: Mapping[Site, NightEvents]
     night_indices: NightIndices
     time_slot_length: timedelta
+    starting_time_slots: StartingTimeSlots
+    ranker: Ranker
 
     # Used to re-score programs.
     _program_scorer: Optional[Callable[[Program,
-                                        Optional[FrozenSet[Site]],
-                                        Optional[NightIndices],
-                                        Optional[Ranker],
-                                        Optional[StartingTimeSlots]],
+                                        FrozenSet[Site],
+                                        NightIndices,
+                                        StartingTimeSlots,
+                                        Ranker],
                               Optional[ProgramCalculations]]] = field(default=None)
 
     def __reduce__(self):
@@ -47,15 +49,10 @@ class Selection:
                                  self.night_indices,
                                  self.time_slot_length))
 
-    def score_program(self,
-                      program: Program,
-                      sites: Optional[FrozenSet[Site]] = None,
-                      night_indices: Optional[NightIndices] = None,
-                      starting_time_slots: Optional[StartingTimeSlots] = None,
-                      ranker: Optional[Ranker] = None) -> ProgramCalculations:
+    def score_program(self, program: Program) -> ProgramCalculations:
         """
-        Re-score a program. This calls Selector.score_program, which checks to make sure
-        that the night_indices are valid, so we don't need to include that logic here.
+        Re-score a program. This calls Selector.score_program.
+
         Note that this will raise a ValueError on unpickled instances of Selection since the
         _program_scorer will be None.
         """
@@ -63,9 +60,7 @@ class Selection:
             raise ValueError('Selection.score_program cannot be called as the selection has a value of None. '
                              'This could happen if the instance was unpickled.')
 
-        if night_indices is None:
-            night_indices = self.night_indices
-        return self._program_scorer(program, sites, night_indices, starting_time_slots, ranker)
+        return self._program_scorer(program, self.sites, self.night_indices, self.starting_time_slots, self.ranker)
 
     @property
     def sites(self) -> FrozenSet[Site]:

--- a/scheduler/core/calculations/selection.py
+++ b/scheduler/core/calculations/selection.py
@@ -9,7 +9,7 @@ from lucupy.helpers import flatten
 from lucupy.minimodel import Group, NightIndices, Program, ProgramID, Site, UniqueGroupID
 
 from scheduler.core.components.ranker import Ranker
-from scheduler.core.types import StartingTimeSlots
+from scheduler.core.types import StartingTimeslots
 from scheduler.core.calculations import GroupData, NightEvents, ProgramCalculations, ProgramInfo
 
 
@@ -28,14 +28,14 @@ class Selection:
     night_events: Mapping[Site, NightEvents]
     night_indices: NightIndices
     time_slot_length: timedelta
-    starting_time_slots: StartingTimeSlots
+    starting_time_slots: StartingTimeslots
     ranker: Ranker
 
     # Used to re-score programs.
     _program_scorer: Optional[Callable[[Program,
                                         FrozenSet[Site],
                                         NightIndices,
-                                        StartingTimeSlots,
+                                        StartingTimeslots,
                                         Ranker],
                               Optional[ProgramCalculations]]] = field(default=None)
 

--- a/scheduler/core/types/__init__.py
+++ b/scheduler/core/types/__init__.py
@@ -1,12 +1,11 @@
-# Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+# Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-from typing import Dict, Tuple
+from typing import Dict
 
 from lucupy.minimodel import NightIndex, Site, TimeslotIndex
 
 # Alias for map from night index to time slot on which to start scoring a group or observation.
 # The scores for all time slots prior to the night's time slot will be set to zero to allow for partial night scoring.
 # Cannot include in Selector since this introduces a circular dependency.
-StartingTimeSlots = Dict[Tuple[Site, NightIndex], TimeslotIndex]
-
+StartingTimeslots = Dict[Site, Dict[NightIndex, TimeslotIndex]]

--- a/scheduler/core/types/__init__.py
+++ b/scheduler/core/types/__init__.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-from typing import Dict
+from typing import Dict, Tuple
 
-from lucupy.minimodel import NightIndex, TimeslotIndex
+from lucupy.minimodel import NightIndex, Site, TimeslotIndex
 
 # Alias for map from night index to time slot on which to start scoring a group or observation.
 # The scores for all time slots prior to the night's time slot will be set to zero to allow for partial night scoring.
 # Cannot include in Selector since this introduces a circular dependency.
-StartingTimeSlots = Dict[NightIndex, TimeslotIndex]
+StartingTimeSlots = Dict[Tuple[Site, NightIndex], TimeslotIndex]
 

--- a/scheduler/scripts/run_greedymax.py
+++ b/scheduler/scripts/run_greedymax.py
@@ -93,17 +93,17 @@ if __name__ == '__main__':
     # Create the overall plans by night.
     overall_plans = {}
     for night_idx in range(selector.num_nights_to_schedule):
-        # Get the night indices for which we are selecting.
-        # TODO: We will want scores for nights to look ahead for greedy optimization.
-        # TODO: For now, we use the entire period for which visibility calculations have been done.
-        # night_indices = range(night_idx, total_nights)
+        # We score one night at a time.
         night_indices = np.array([night_idx])
-        starting_time_slots = {(Site.GS, night_idx): 400}
-        # selection = selector.select(night_indices=np.array([0, 1, 2])
-        selection = selector.select(night_indices=night_indices, starting_time_slots=starting_time_slots)
 
-        # Run the optimizer to get the plans for the first night in the selection.
+        # TODO: Remove. Example: ensure that the first 400 time slots for each night in GS are empty.
+        starting_time_slots = {Site.GS: {night_idx: 400}}
+
+        # Retrieve the Selection and run the Optimizer to get the plans.
+        selection = selector.select(night_indices=night_indices, starting_time_slots=starting_time_slots)
         plans = optimizer.schedule(selection)
+
+        # The Optimizer currently returns plans for all nights. We only want the first set.
         night_plans = plans[0]
 
         # Store the plans in the overall_plans array for that night.

--- a/scheduler/scripts/run_greedymax.py
+++ b/scheduler/scripts/run_greedymax.py
@@ -98,8 +98,9 @@ if __name__ == '__main__':
         # TODO: For now, we use the entire period for which visibility calculations have been done.
         # night_indices = range(night_idx, total_nights)
         night_indices = np.array([night_idx])
+        starting_time_slots = {(Site.GS, night_idx): 400}
         # selection = selector.select(night_indices=np.array([0, 1, 2])
-        selection = selector.select(night_indices=night_indices)
+        selection = selector.select(night_indices=night_indices, starting_time_slots=starting_time_slots)
 
         # Run the optimizer to get the plans for the first night in the selection.
         plans = optimizer.schedule(selection)


### PR DESCRIPTION
This PR:
* Simplifies some function calls for scoring programs by removing parameters that should be set.
* Fixes calls from GreedyMax to use the starting time slots instead of starting back at time slot 0.
* Changes the structure of the lookup for starting time slots.