### PR TITLE
SCHED-491: Time accounting can now be done for partial nights.

### DIFF
--- a/scheduler/core/components/selector/__init__.py
+++ b/scheduler/core/components/selector/__init__.py
@@ -71,7 +71,7 @@ class Selector(SchedulerComponent):
 
             # Check for extra keys.
             if extra_keys := night_dict.keys() - night_indices:
-                raise ValueError(f'Extra night indices for site {site.name}: {extra_keys}')
+                logger.warning(f'Extra night indices for site {site.name} for starting_time_slots: {extra_keys}')
 
         return starting_time_slots
 
@@ -390,10 +390,12 @@ class Selector(SchedulerComponent):
                 np.multiply(conditions_score[night_idx], obs_scores[night_idx]),
                 wind_score[night_idx]) for night_idx in night_indices}
 
-        # Zero out the data for each night index's starting time slots prior to the value specified.
+        # Zero out the data for each night index's starting time slots prior to the value specified (if specified)
+        # and the night index was included in scoring.
         starting_time_slots_for_site = starting_time_slots[obs.site]
         for night_idx, time_slot_idx in starting_time_slots_for_site.items():
-            scores[night_idx][:time_slot_idx] = 0.0
+            if night_idx in night_indices:
+                scores[night_idx][:time_slot_idx] = 0.0
 
         # These scores might differ from the observation score in the ranker since they have been adjusted for
         # conditions and wind.

--- a/scheduler/scripts/run_greedymax.py
+++ b/scheduler/scripts/run_greedymax.py
@@ -4,8 +4,7 @@
 import os
 import logging
 
-from lucupy.minimodel.constraints import CloudCover, ImageQuality
-from lucupy.minimodel.site import ALL_SITES
+from lucupy.minimodel import ALL_SITES, CloudCover, ImageQuality, NightIndex
 from lucupy.minimodel.semester import SemesterHalf
 from lucupy.observatory.abstract import ObservatoryProperties
 from lucupy.observatory.gemini import GeminiProperties
@@ -90,14 +89,15 @@ if __name__ == '__main__':
     # The total nights for which visibility calculations have been done.
     total_nights = len(collector.time_grid)
 
+    # Example: ensure that the first 400 time slots for night_idx 1 for GS are empty.
+    starting_time_slots = {Site.GS: {NightIndex(1): 400}}
+    # starting_time_slots = None
+
     # Create the overall plans by night.
     overall_plans = {}
-    for night_idx in range(selector.num_nights_to_schedule):
+    for night_idx in map(NightIndex, range(selector.num_nights_to_schedule)):
         # We score one night at a time.
         night_indices = np.array([night_idx])
-
-        # TODO: Remove. Example: ensure that the first 400 time slots for each night in GS are empty.
-        starting_time_slots = {Site.GS: {night_idx: 400}}
 
         # Retrieve the Selection and run the Optimizer to get the plans.
         selection = selector.select(night_indices=night_indices, starting_time_slots=starting_time_slots)

--- a/scheduler/scripts/run_greedymax_twice.py
+++ b/scheduler/scripts/run_greedymax_twice.py
@@ -9,9 +9,7 @@
 import os
 import logging
 
-from lucupy.minimodel.constraints import CloudCover, ImageQuality
-from lucupy.minimodel.site import ALL_SITES
-from lucupy.minimodel.semester import SemesterHalf
+from lucupy.minimodel import ALL_SITES, CloudCover, ImageQuality, NightIndex, SemesterHalf
 from lucupy.observatory.abstract import ObservatoryProperties
 from lucupy.observatory.gemini import GeminiProperties
 
@@ -28,7 +26,7 @@ if __name__ == '__main__':
     logger = logger_factory.create_logger(__name__, logging.INFO)
     ObservatoryProperties.set_properties(GeminiProperties)
 
-    print('***** RUN 1 *****')
+    print('***** RUN 1: GN and GS *****')
     # Read in a list of JSON data
     programs = read_ocs_zipfile(os.path.join(ROOT_DIR, 'scheduler', 'data', '2018B_program_samples.zip'))
 
@@ -79,12 +77,7 @@ if __name__ == '__main__':
     # Create the overall plans by night.
     overall_plans = {}
     for night_idx in range(selector.num_nights_to_schedule):
-        # Get the night indices for which we are selecting.
-        # TODO: We will want scores for nights to look ahead for greedy optimization.
-        # TODO: For now, we use the entire period for which visibility calculations have been done.
-        # night_indices = range(night_idx, total_nights)
         night_indices = np.array([night_idx])
-        # selection = selector.select(night_indices=np.array([0, 1, 2])
         selection = selector.select(night_indices=night_indices)
 
         # Run the optimizer to get the plans for the first night in the selection.
@@ -101,7 +94,7 @@ if __name__ == '__main__':
     overall_plans = [p for _, p in sorted(overall_plans.items())]
     print_plans(overall_plans)
 
-    print('\n\n\n***** RUN 2 *****')
+    print('\n\n\n***** RUN 2: GS ONLY *****')
     # Read in a list of JSON data
     programs = read_ocs_zipfile(os.path.join(ROOT_DIR, 'scheduler', 'data', '2018B_program_samples.zip'))
 
@@ -152,12 +145,7 @@ if __name__ == '__main__':
     # Create the overall plans by night.
     overall_plans = {}
     for night_idx in range(selector.num_nights_to_schedule):
-        # Get the night indices for which we are selecting.
-        # TODO: We will want scores for nights to look ahead for greedy optimization.
-        # TODO: For now, we use the entire period for which visibility calculations have been done.
-        # night_indices = range(night_idx, total_nights)
         night_indices = np.array([night_idx])
-        # selection = selector.select(night_indices=np.array([0, 1, 2])
         selection = selector.select(night_indices=night_indices)
 
         # Run the optimizer to get the plans for the first night in the selection.


### PR DESCRIPTION
Time accounting can now be done for specified sites for partial nights, up to (excluding) a specified time slot for each night.

If an event occurs at time `t` for Site `s`, then calling:

```
collector.time_accounting(plans, sites=frozenset({s}), end_timeslot_bounds={s: t})
```

will only perform time accounting for visits in the plan for site `s` up until timeslot `t`.

Then it will be possible to perform another selection for the site starting at timeslot `t` (when the event occurred) and run the optimizer from that point.
All previous timeslots will be unused: the scores for the observations at site `s` will be set to `0` for all timeslots prior to `t`, which means nothing will be scheduled for them in the plan.

This allows us to make partial plans of decreasing length from different starting points in the night to the end of the night, and perform the necessary time accounting on them.

**NOTE:** This does not yet allow for completing partial visits. If a visit occurs over timeslot `t`, the entire visit (and all subsequent visits) will be ignored as having been _interrupted_ by the event.

Additional note:
As a starting point, since `NightIndex` is declared as a `NewType('NightIndex', int)`, making it a formal subclass of `int`, we should theoretically be wrapping all `NightIndex` values with `NightIndex(idx)` instead of just using an int `idx`, so I included that in `run_greedymax.py`. Note that this is NOT NECESSARY and will still run fine either way, but we should be conscious of this moving forward and wrap `NightIndex` (and `TimeSlotIndex`) appropriately. I'll make a low priority Jira task for this.