### PR TITLE
SCHED-495: Improve plan output

### DIFF
--- a/scheduler/core/output/__init__.py
+++ b/scheduler/core/output/__init__.py
@@ -128,12 +128,16 @@ def print_plans(all_plans: List[Plans]) -> None:
         print(f'\n\n+++++ NIGHT {plans.night_idx + 1} +++++')
         for plan in plans:
             print(f'Plan for site: {plan.site.name}')
+            # Print header information
+            max_score_length = max(len(f'{visit.score:8.2f}') for visit in plan.visits)
+            print(f'\t{"Execution time":{36}}    {"ObsID":{20}} {"Score":>{max_score_length}}'
+                  '  StartAtom    EndAtom  StartSlot    EndSlot   NumSlots')
             for visit in plan.visits:
                 start_time_str = visit.start_time.strftime('%Y-%m-%d %H:%M')
                 end_time_str = (visit.start_time + timedelta(minutes=visit.time_slots)).strftime('%Y-%m-%d %H:%M')
-                print(f'\t{start_time_str} to {end_time_str}:   {visit.obs_id.id:20} {visit.score:8.2f} '
-                      f'{visit.atom_start_idx:4d} {visit.atom_end_idx:4d} {visit.start_time_slot:4d} '
-                      f'{visit.time_slots:3d}')
+                print(f'\t{start_time_str} to {end_time_str}:   {visit.obs_id.id:20} {visit.score:8.2f}  '
+                      f'{visit.atom_start_idx:9d}  {visit.atom_end_idx:9d}  {visit.start_time_slot:9d}  '
+                      f' {(visit.start_time_slot + visit.time_slots):9d} {visit.time_slots:9d}')
 
 
 def plans_table(all_plans: List[Plans]) -> List[Dict[Site, DataFrame]]:

--- a/scheduler/core/output/__init__.py
+++ b/scheduler/core/output/__init__.py
@@ -129,8 +129,11 @@ def print_plans(all_plans: List[Plans]) -> None:
         for plan in plans:
             print(f'Plan for site: {plan.site.name}')
             for visit in plan.visits:
-                print(f'\t{visit.start_time}   {visit.obs_id.id:20} {visit.score:8.2f} {visit.atom_start_idx:4d} '
-                      f'{visit.atom_end_idx:4d}')
+                start_time_str = visit.start_time.strftime('%Y-%m-%d %H:%M')
+                end_time_str = (visit.start_time + timedelta(minutes=visit.time_slots)).strftime('%Y-%m-%d %H:%M')
+                print(f'\t{start_time_str} to {end_time_str}:   {visit.obs_id.id:20} {visit.score:8.2f} '
+                      f'{visit.atom_start_idx:4d} {visit.atom_end_idx:4d} {visit.start_time_slot:4d} '
+                      f'{visit.time_slots:3d}')
 
 
 def plans_table(all_plans: List[Plans]) -> List[Dict[Site, DataFrame]]:


### PR DESCRIPTION
Due to the fact that `Visit`s seem to be overlapping in `Plan`s, I am adding extra output about the end time and number of time slots for each `Visit` to the output, and adding a header row to the table along with extra spacing to make the data easier to read.