### PR TITLE
SCHED-497: Cleanup for Py3.12 migration.

### DIFF
--- a/scheduler/core/builder/__init__.py
+++ b/scheduler/core/builder/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 from .builder import *
 from .blueprint import Blueprints

--- a/scheduler/core/builder/modes.py
+++ b/scheduler/core/builder/modes.py
@@ -5,7 +5,7 @@
 from enum import Enum
 from .builder import ValidationBuilder, SchedulerBuilder
 from scheduler.core.sources import Sources
-import strawberry
+import strawberry  # noqa
 
 from ..eventsqueue import EventQueue
 
@@ -32,4 +32,3 @@ def dispatch_with(mode: SchedulerModes, sources: Sources, events: EventQueue) ->
             raise ValueError(f'{mode.value} not implemented yet.')
         case SchedulerModes.OPERATION:
             raise ValueError(f'{mode.value} not implemented yet.')
-

--- a/scheduler/core/calculations/groupinfo.py
+++ b/scheduler/core/calculations/groupinfo.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass
 from typing import Dict
 
-from lucupy.minimodel import Conditions, Group, NightIndex, UniqueGroupID
+from lucupy.minimodel import Conditions, Group, NightIndex, TimeslotIndex, UniqueGroupID
 import numpy.typing as npt
 
 from .scores import Scores
@@ -35,7 +35,7 @@ class GroupInfo:
     night_filtering: Dict[NightIndex, bool]
     conditions_score: Dict[NightIndex, npt.NDArray[float]]
     wind_score: Dict[NightIndex, npt.NDArray[float]]
-    schedulable_slot_indices: Dict[NightIndex, npt.NDArray[int]]
+    schedulable_slot_indices: Dict[NightIndex, npt.NDArray[TimeslotIndex]]
     scores: Scores
 
 

--- a/scheduler/core/calculations/scores.py
+++ b/scheduler/core/calculations/scores.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+# Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 from typing import Dict
@@ -7,8 +7,8 @@ from lucupy.minimodel import NightIndex
 import numpy.typing as npt
 
 # Scores for the timeslots in a specific night.
-NightTimeSlotScores = npt.NDArray[float]
+NightTimeslotScores = npt.NDArray[float]
 
 # Scores across all nights per timeslot.
 # Indexed by night index, and then timeslot index.
-Scores = Dict[NightIndex, NightTimeSlotScores]
+Scores = Dict[NightIndex, NightTimeslotScores]

--- a/scheduler/core/calculations/selection.py
+++ b/scheduler/core/calculations/selection.py
@@ -1,9 +1,9 @@
-# Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+# Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import timedelta
-from typing import Callable, FrozenSet, Mapping, Optional
+from typing import final, Callable, FrozenSet, Mapping, Optional
 
 from lucupy.helpers import flatten
 from lucupy.minimodel import Group, NightIndices, Program, ProgramID, Site, UniqueGroupID
@@ -13,6 +13,7 @@ from scheduler.core.types import StartingTimeslots
 from scheduler.core.calculations import GroupData, NightEvents, ProgramCalculations, ProgramInfo
 
 
+@final
 @dataclass(frozen=True)
 class Selection:
     """
@@ -37,7 +38,7 @@ class Selection:
                                         NightIndices,
                                         StartingTimeslots,
                                         Ranker],
-                              Optional[ProgramCalculations]]] = field(default=None)
+                              Optional[ProgramCalculations]]] = None
 
     def __reduce__(self):
         """

--- a/scheduler/core/calculations/targetinfo.py
+++ b/scheduler/core/calculations/targetinfo.py
@@ -2,7 +2,7 @@
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 from dataclasses import dataclass
-from typing import Dict, Tuple
+from typing import final, Dict, Tuple
 
 import numpy as np
 import numpy.typing as npt
@@ -13,6 +13,7 @@ from lucupy.minimodel import NightIndex, ObservationID, SkyBackground, TargetNam
 
 
 @immutable
+@final
 @dataclass(frozen=True)
 class TargetInfo:
     """

--- a/scheduler/core/components/base/__init__.py
+++ b/scheduler/core/components/base/__init__.py
@@ -4,7 +4,6 @@
 from abc import ABC
 
 
-# TODO: Perhaps makes SchedulerComponent a Singleton since we only need one instance of each during each execution.
 class SchedulerComponent(ABC):
     """
     Base class for all Scheduler components involved in the pipeline.

--- a/scheduler/core/components/optimizer/__init__.py
+++ b/scheduler/core/components/optimizer/__init__.py
@@ -1,9 +1,10 @@
-# Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+# Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 from typing import List
 
 from scheduler.core.calculations.selection import Selection
+from scheduler.core.components.optimizer.base import BaseOptimizer
 from scheduler.core.plans import Plans
 
 from lucupy.minimodel import Program
@@ -15,7 +16,7 @@ class Optimizer:
     All algorithms need to follow the same structure to create a Plan
     """
 
-    def __init__(self, algorithm=None):
+    def __init__(self, algorithm: BaseOptimizer):
         """
         All sites schedule the same number of nights.
         The number of nights scheduled at one time is determined by the Selection.night_indices, passed

--- a/scheduler/core/components/optimizer/base.py
+++ b/scheduler/core/components/optimizer/base.py
@@ -1,15 +1,14 @@
-# Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+# Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Mapping, List
-from lucupy.minimodel.program import ProgramID
+from typing import List
 from lucupy.types import Interval
 
 from scheduler.core.calculations.groupinfo import GroupData
-from scheduler.core.calculations.programinfo import ProgramInfo
+from scheduler.core.calculations.selection import Selection
 from scheduler.core.plans import Plans
 
 
@@ -48,8 +47,7 @@ class BaseOptimizer(ABC):
         ...
 
     @abstractmethod
-    # def setup(self, selection: Selection):
-    def setup(self, program_info: Mapping[ProgramID, ProgramInfo]):
+    def setup(self, selection: Selection):
         ...
 
     @abstractmethod

--- a/scheduler/core/components/optimizer/greedymax.py
+++ b/scheduler/core/components/optimizer/greedymax.py
@@ -11,12 +11,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
 from lucupy.minimodel import (NIR_INSTRUMENTS, Group, NightIndex, Observation, ObservationClass, ObservationID,
-                              ObservationStatus, Program, QAState, Sequence, Site, UniqueGroupID, Wavelengths,
-                              ObservationMode)
+                              ObservationStatus, Program, QAState, Site, UniqueGroupID, Wavelengths, ObservationMode)
 from lucupy.minimodel.resource import Resource
 from lucupy.types import Interval, ZeroTime
 
-from scheduler.core.calculations import GroupData, NightTimeSlotScores
+from scheduler.core.calculations import GroupData, NightTimeslotScores
 from scheduler.core.calculations.selection import Selection
 from scheduler.core.components.optimizer.timeline import Timelines
 from scheduler.core.plans import Plan, Plans
@@ -78,7 +77,7 @@ class GreedyMaxOptimizer(BaseOptimizer):
         return self
 
     @staticmethod
-    def non_zero_intervals(scores: NightTimeSlotScores) -> npt.NDArray[int]:
+    def non_zero_intervals(scores: NightTimeslotScores) -> npt.NDArray[int]:
         """
         Calculate the non-zero intervals in the data.
         This consists of an array with entries of the form [a, b] where
@@ -89,7 +88,7 @@ class GreedyMaxOptimizer(BaseOptimizer):
         instead of using Interval.
         """
         # Create an array that is 1 where the score is greater than 0, and pad each end with an extra 0.
-        not_zero = np.concatenate(([0], np.greater(scores, 0), [0]))
+        not_zero = np.concatenate((np.array([0]), np.greater(scores, 0), np.array([0])))
         abs_diff = np.abs(np.diff(not_zero))
 
         # Return the ranges for each nonzero interval.
@@ -673,7 +672,7 @@ class GreedyMaxOptimizer(BaseOptimizer):
         plt.show()
 
     @staticmethod
-    def _plot_interval(score: NightTimeSlotScores,
+    def _plot_interval(score: NightTimeslotScores,
                        interval: Interval,
                        best_interval: Interval,
                        label: str = "") -> None:
@@ -817,9 +816,13 @@ class GreedyMaxOptimizer(BaseOptimizer):
         atom_end = atom_start
 
         n_slots_acq = Plan.time2slots(self.time_slot_length, obs.acq_overhead)
+
+        # type inspector cannot infer that cumul_seq[idx] is a timedelta.
+        # noinspection PyTypeChecker
         visit_length = n_slots_acq + Plan.time2slots(self.time_slot_length, cumul_seq[atom_end])
         while n_slots_filled + visit_length <= len(best_interval) and atom_end <= len(cumul_seq) - 2:
             atom_end += 1
+            # noinspection PyTypeChecker
             visit_length = n_slots_acq + Plan.time2slots(self.time_slot_length, cumul_seq[atom_end])
 
         n_slots_filled += visit_length

--- a/scheduler/core/components/optimizer/timeline.py
+++ b/scheduler/core/components/optimizer/timeline.py
@@ -87,6 +87,7 @@ class Timeline:
         else:
             print(f'ERROR: timeline.add. No empty time slots.')
 
+        # noinspection PyTypeChecker
         return start_time_slot, start
 
     def get_observation_order(self) -> List[Tuple[int, int, int]]:

--- a/scheduler/core/components/ranker/__init__.py
+++ b/scheduler/core/components/ranker/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 from .default import DefaultRanker
 from .base import Ranker

--- a/scheduler/core/components/selector/__init__.py
+++ b/scheduler/core/components/selector/__init__.py
@@ -492,6 +492,8 @@ class Selector(SchedulerComponent):
 
         # The schedulable slot indices are the unions of the schedulable slot indices for each subgroup
         # across each night.
+        # Type checker is balking here at the list of npt.NDArray[TimeslotIndex].
+        # noinspection PyTypeChecker
         schedulable_slot_indices = {
             night_idx:
             # For each night, take the concatenation of the schedulable time slots for all children of the group

--- a/scheduler/core/service/service.py
+++ b/scheduler/core/service/service.py
@@ -3,16 +3,12 @@
 
 import os
 
-from typing import Dict, FrozenSet, Mapping, List, Tuple
+from typing import FrozenSet
 from astropy.time import Time
-from lucupy.minimodel import Site, Semester, Band, Conditions, ProgramID
-
+from lucupy.minimodel import Site, Semester
 
 from scheduler.core.programprovider.ocs import read_ocs_zipfile, OcsProgramProvider
 from scheduler.core.builder import SchedulerBuilder, Blueprints
-from scheduler.core.components.collector import Collector
-from scheduler.core.calculations.selection import Selection
-from scheduler.core.plans import NightStats, Plans
 from scheduler.core.statscalculator import StatCalculator
 from scheduler.db.planmanager import PlanManager
 
@@ -84,4 +80,3 @@ def build_service(start: Time,
                            Semester.find_semester_from_date(end.to_value('datetime'))])
 
     return Service(start, end, num_nights_to_schedule, semesters, sites, builder)
-

--- a/scheduler/db/dbmanager.py
+++ b/scheduler/db/dbmanager.py
@@ -24,7 +24,8 @@ class DBManager:
     def __init__(self, db_path):
         self.db_path = db_path
 
-    def read(self, start_date: Optional[str] = None,
+    def read(self,
+             start_date: Optional[str] = None,
              end_date: Optional[str] = None,
              site: Optional[FrozenSet[Site]] = None) -> List[SPlans]:
         with locking(f'{self.db_path}.lock', LOCK_SH):

--- a/scheduler/db/planmanager.py
+++ b/scheduler/db/planmanager.py
@@ -1,9 +1,9 @@
-# Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+# Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 import os
 from copy import deepcopy
-from typing import List, FrozenSet
+from typing import FrozenSet, List, Optional
 from lucupy.minimodel import Site
 
 from scheduler.core.plans import Plans
@@ -37,7 +37,7 @@ class PlanManager:
             raise KeyError('Error on read.')
 
     @staticmethod
-    def get_plans_by_input(start_date: str, end_date: str, site: FrozenSet[Site]) -> List[SPlans]:
+    def get_plans_by_input(start_date: str, end_date: str, site: FrozenSet[Site]) -> Optional[List[SPlans]]:
         """
         A more specific way to get plans by the `CreateNewSchedule` input.
         """

--- a/scheduler/graphql_mid/inputs.py
+++ b/scheduler/graphql_mid/inputs.py
@@ -1,10 +1,12 @@
 # Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 from datetime import datetime
 
 import strawberry  # noqa
 from strawberry.file_uploads import Upload  # noqa
 from typing import Optional, List
+
 from .scalars import Sites
 from scheduler.core.builder.modes import SchedulerModes
 


### PR DESCRIPTION
Necessary fix to `RankerParameters` for Python 3.12 and the elimination of several warnings.