### PR TITLE
SCHED-503B: Event handling cleanup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,5 +21,4 @@ gelidum
 python-dateutil
 mercury
 bleach>=6.0.0
-typing
 sortedcontainers

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ astropy
 hypothesis
 matplotlib
 more-itertools
-numpy>=1.23.*, <1.25
+numpy
 openpyxl
 pandas
 pytest
@@ -20,4 +20,6 @@ pytest-asyncio
 gelidum
 python-dateutil
 mercury
-bleach >=6.0.0
+bleach>=6.0.0
+typing
+sortedcontainers

--- a/scheduler/core/eventsqueue/__init__.py
+++ b/scheduler/core/eventsqueue/__init__.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-from .event_queue import EventQueue
-from .events import (Event, Interruption, Blockage,
-                     WeatherChange, ResumeNight, Fault)
+from .event_queue import *
+from .events import *

--- a/scheduler/core/eventsqueue/event_queue.py
+++ b/scheduler/core/eventsqueue/event_queue.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-from collections import deque
-from typing import Deque, FrozenSet, Iterable, Optional
+from dataclasses import dataclass, field
+from sortedcontainers import SortedList
+from typing import FrozenSet, Iterable, Optional
 
 from lucupy.minimodel import NightIndex, Site
 
@@ -12,9 +13,31 @@ from .events import Blockage, Event, Interruption, ResumeNight
 logger = logger_factory.create_logger(__name__)
 
 
+__all__ = ['EventQueue']
+
+
+@dataclass
+class NightEventQueue:
+    night_idx: NightIndex
+    site: Site
+
+    # events is a list managed by heapq.
+    events: SortedList[Event] = field(init=False, default_factory=lambda: SortedList(key=lambda evt: evt.start))
+
+    def has_more_events(self) -> bool:
+        return len(self.events) > 0
+
+    def next_event(self) -> Event:
+        return self.events.pop(0)
+
+    def add_event(self, event: Event) -> None:
+        self.events.add(event)
+
+
 class EventQueue:
     def __init__(self, night_indices: FrozenSet[NightIndex], sites: FrozenSet[Site]):
-        self._events = {night_idx: {site: deque([]) for site in sites} for night_idx in night_indices}
+        self._events = {night_idx: {site: NightEventQueue(night_idx=night_idx, site=site) for site in sites}
+                        for night_idx in night_indices}
         self._blockage_stack = []
 
     def add_event(self, night_idx: NightIndex, site: Site, event: Event) -> None:
@@ -22,11 +45,11 @@ class EventQueue:
             case Blockage():
                 self._blockage_stack.append(event)
             case Interruption():
-                site_deque = self.get_night_events(night_idx, site)
-                if site_deque is not None:
-                    site_deque.append(event)
+                site_events = self.get_night_events(night_idx, site)
+                if site_events is not None:
+                    site_events.add_event(event)
                 else:
-                    raise KeyError(f'Could not add event {event} for night index {night_idx }to site {site.name}.')
+                    raise KeyError(f'Could not add event {event} for night index {night_idx} to site {site.name}.')
 
     def add_events(self, night_idx: NightIndex, site: Site, events: Iterable[Event]) -> None:
         for event in events:
@@ -37,18 +60,17 @@ class EventQueue:
             b = self._blockage_stack.pop()
             b.ends(resume_event.start)
             return b
-
         raise RuntimeError('Missing blockage for ResumeNight')
 
-    def get_night_events(self, night_idx: NightIndex, site: Site) -> Optional[Deque[Event]]:
+    def get_night_events(self, night_idx: NightIndex, site: Site) -> Optional[NightEventQueue]:
         """
-        Returns the deque for the site for the night index if it exists, else None.
+        Returns the sorted list for the site for the night index if it exists, else None.
         """
-        night_deques = self._events.get(night_idx)
-        if night_deques is None:
+        night_lists = self._events.get(night_idx)
+        if night_lists is None:
             logger.error(f'Tried to access event queue for inactive night index {night_idx}.')
             return None
-        site_deque = night_deques.get(site)
-        if site_deque is None:
+        site_list = night_lists.get(site)
+        if site_list is None:
             logger.error(f'Tried to access event queue for night index {night_idx} for inactive site {site.name}.')
-        return site_deque
+        return site_list

--- a/scheduler/core/eventsqueue/events.py
+++ b/scheduler/core/eventsqueue/events.py
@@ -4,9 +4,10 @@
 from abc import ABC
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from math import ceil
 from typing import FrozenSet
 
-from lucupy.minimodel import Resource, Conditions, Site
+from lucupy.minimodel import Resource, Conditions, Site, TimeslotIndex
 
 
 @dataclass
@@ -73,3 +74,13 @@ class WeatherChange(Interruption):
     Interruption that occurs when new weather conditions come in.
     """
     new_conditions: Conditions
+
+
+# Calculate the starting time slot of an event.
+def event_datetime_to_timeslot(event: Event, twi_eve: datetime, time_slot_length: timedelta) -> TimeslotIndex:
+    """
+    Given an event, calculate the timeslot it falls in from twilight.
+    """
+    time_from_twilight = event.start - twi_eve
+    number_timeslots = ceil(time_from_twilight / time_slot_length)
+    return TimeslotIndex(number_timeslots)

--- a/scheduler/core/eventsqueue/events.py
+++ b/scheduler/core/eventsqueue/events.py
@@ -30,7 +30,7 @@ class Event(ABC):
 
 
 @dataclass
-class Interruption(Event):
+class Interruption(Event, ABC):
     """
     Parent class for any interruption that might cause a new schedule to be created.
     """
@@ -38,7 +38,7 @@ class Interruption(Event):
 
 
 @dataclass
-class Twilight(Interruption):
+class Twilight(Interruption, ABC):
     """
     An event indicating that the 12 degree starting twilight for a night has been reached.
     """
@@ -54,8 +54,17 @@ class EveningTwilight(Twilight):
     ...
 
 
+@final
 @dataclass
-class Blockage(Event):
+class WeatherChange(Interruption):
+    """
+    Interruption that occurs when new weather conditions come in.
+    """
+    new_conditions: Conditions
+
+
+@dataclass
+class Blockage(Event, ABC):
     """
     Parent class for any interruption that causes a blockage and requires a resume event.
     """
@@ -85,12 +94,3 @@ class Fault(Blockage):
     Blockage that occurs when one or more resources experience a fault.
     """
     affects: FrozenSet[Resource]
-
-
-@final
-@dataclass
-class WeatherChange(Interruption):
-    """
-    Interruption that occurs when new weather conditions come in.
-    """
-    new_conditions: Conditions

--- a/scheduler/core/eventsqueue/events.py
+++ b/scheduler/core/eventsqueue/events.py
@@ -5,7 +5,7 @@ from abc import ABC
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from math import ceil
-from typing import FrozenSet
+from typing import final, FrozenSet, Optional
 
 from lucupy.minimodel import Resource, Conditions, Site, TimeslotIndex
 
@@ -45,12 +45,21 @@ class Twilight(Interruption):
     ...
 
 
+@final
+@dataclass
+class EveningTwilight(Twilight):
+    """
+    An event indicating that the 12 degree starting twilight for a night has been reached.
+    """
+    ...
+
+
 @dataclass
 class Blockage(Event):
     """
     Parent class for any interruption that causes a blockage and requires a resume event.
     """
-    end: datetime = None  # needs a resume event
+    end: Optional[datetime] = None  # needs a resume event
 
     def ends(self, end: datetime) -> None:
         self.end = end
@@ -70,6 +79,7 @@ class ResumeNight(Interruption):
     ...
 
 
+@final
 class Fault(Blockage):
     """
     Blockage that occurs when one or more resources experience a fault.
@@ -77,6 +87,7 @@ class Fault(Blockage):
     affects: FrozenSet[Resource]
 
 
+@final
 @dataclass
 class WeatherChange(Interruption):
     """

--- a/scheduler/core/eventsqueue/events.py
+++ b/scheduler/core/eventsqueue/events.py
@@ -19,6 +19,15 @@ class Event(ABC):
     reason: str
     site: Site
 
+    def to_timeslot_idx(self, twi_eve_time: datetime, time_slot_length: timedelta) -> TimeslotIndex:
+        """
+        Given an event, calculate the timeslot offset it falls into relative to another datetime.
+        This would typically be the twilight of the night on which the event occurs, hence the name twi_eve_time.
+        """
+        time_from_twilight = self.start - twi_eve_time
+        time_slots_from_twilight = ceil(time_from_twilight / time_slot_length)
+        return TimeslotIndex(time_slots_from_twilight)
+
 
 @dataclass
 class Interruption(Event):
@@ -74,13 +83,3 @@ class WeatherChange(Interruption):
     Interruption that occurs when new weather conditions come in.
     """
     new_conditions: Conditions
-
-
-# Calculate the starting time slot of an event.
-def event_datetime_to_timeslot(event: Event, twi_eve: datetime, time_slot_length: timedelta) -> TimeslotIndex:
-    """
-    Given an event, calculate the timeslot it falls in from twilight.
-    """
-    time_from_twilight = event.start - twi_eve
-    number_timeslots = ceil(time_from_twilight / time_slot_length)
-    return TimeslotIndex(number_timeslots)

--- a/scheduler/core/eventsqueue/events.py
+++ b/scheduler/core/eventsqueue/events.py
@@ -20,20 +20,18 @@ class Event(ABC):
 
 
 @dataclass
-class Interruption(ABC):
+class Interruption(Event):
     """
     Parent class for any interruption that might cause a new schedule to be created.
     """
-    start: datetime
-    reason: str
-    site: Site
-
-    def __str__(self):
-        return self.__class__.__name__
+    ...
 
 
 @dataclass
 class Twilight(Interruption):
+    """
+    An event indicating that the 12 degree starting twilight for a night has been reached.
+    """
     ...
 
 
@@ -75,6 +73,3 @@ class WeatherChange(Interruption):
     Interruption that occurs when new weather conditions come in.
     """
     new_conditions: Conditions
-
-
-Event = Interruption | Blockage


### PR DESCRIPTION
This PR:
* Turns `EveningTwilight` into a bonafide event. Without it, a night will not be scheduled.
* Uses a wrapper around a `SortedList` to manage the events for a given night index for a given site.
* Removes the redundancy of doing an initial `Selection` and then a `Selection` for each event: since `EveningTwilight` is now a full class `Event`, it is expected to be the first `Event` of a night for a site: it will set the starting time for the night so that the time slots can be calculated from the other `Event`s that occur. If `EveningTwilight` is missing, we cannot calculate time slots for other `Event`s for a night and the code fails.
* `Event`s have been marked either `ABC` or `@final`.
* `Event`s now have a method to calculate the time slot in which they occur.
* Removes redundant `if` statement around event processing.