### PR TITLE
SCHED-486: Observations marked ON_HOLD or PHASE2 are no longer included

### DIFF
--- a/scheduler/core/components/selector/__init__.py
+++ b/scheduler/core/components/selector/__init__.py
@@ -287,13 +287,12 @@ class Selector(SchedulerComponent):
             raise ValueError(f'Non-observation group {group.id} cannot be treated as observation group.')
 
         obs = group.children
-        # *** HERE ***
-        # if obs.status in {ObservationStatus.OBSERVED, ObservationStatus.INACTIVE}:
-        #     logger.warning(f'Observation {obs.id.id} has a status of {obs.status.name}. Skipping.')
-        #     return group_data_map
-        #
-        # if obs.status not in {ObservationStatus.READY, ObservationStatus.ONGOING}:
-        #     raise ValueError(f'Observation {obs.id.id} has a status of {obs.status.name}.')
+        if obs.status in {ObservationStatus.OBSERVED, ObservationStatus.INACTIVE}:
+            logger.warning(f'Observation {obs.id.id} has a status of {obs.status.name}. Skipping.')
+            return group_data_map
+
+        if obs.status not in {ObservationStatus.READY, ObservationStatus.ONGOING}:
+            raise ValueError(f'Observation {obs.id.id} has a status of {obs.status.name}.')
 
         # This should never happen.
         if obs.site not in sites:

--- a/scheduler/core/components/selector/__init__.py
+++ b/scheduler/core/components/selector/__init__.py
@@ -287,6 +287,8 @@ class Selector(SchedulerComponent):
             raise ValueError(f'Non-observation group {group.id} cannot be treated as observation group.')
 
         obs = group.children
+        if obs.status == ObservationStatus.PHASE2 or obs.status == ObservationStatus.ON_HOLD:
+            raise ValueError(f'Observation {obs.id.id} has a status of {obs.status.name}.')
 
         # Only schedule ONGOING or READY observations.
         if obs.status not in {ObservationStatus.ONGOING, ObservationStatus.READY}:

--- a/scheduler/core/components/selector/__init__.py
+++ b/scheduler/core/components/selector/__init__.py
@@ -287,13 +287,13 @@ class Selector(SchedulerComponent):
             raise ValueError(f'Non-observation group {group.id} cannot be treated as observation group.')
 
         obs = group.children
-        if obs.status == ObservationStatus.PHASE2 or obs.status == ObservationStatus.ON_HOLD:
-            raise ValueError(f'Observation {obs.id.id} has a status of {obs.status.name}.')
-
-        # Only schedule ONGOING or READY observations.
-        if obs.status not in {ObservationStatus.ONGOING, ObservationStatus.READY}:
-            logger.warning(f'Selector skipping observation {obs.id}: status is {obs.status.name}.')
-            return group_data_map
+        # *** HERE ***
+        # if obs.status in {ObservationStatus.OBSERVED, ObservationStatus.INACTIVE}:
+        #     logger.warning(f'Observation {obs.id.id} has a status of {obs.status.name}. Skipping.')
+        #     return group_data_map
+        #
+        # if obs.status not in {ObservationStatus.READY, ObservationStatus.ONGOING}:
+        #     raise ValueError(f'Observation {obs.id.id} has a status of {obs.status.name}.')
 
         # This should never happen.
         if obs.site not in sites:

--- a/scheduler/core/programprovider/ocs/__init__.py
+++ b/scheduler/core/programprovider/ocs/__init__.py
@@ -53,7 +53,10 @@ class OcsProgramProvider(ProgramProvider):
     _GPI_FILTER_WAVELENGTHS = {'Y': 1.05, 'J': 1.25, 'H': 1.65, 'K1': 2.05, 'K2': 2.25}
     _NIFS_FILTER_WAVELENGTHS = {'ZJ': 1.05, 'JH': 1.25, 'HK': 2.20}
     _OBSERVE_TYPES = frozenset(['FLAT', 'ARC', 'DARK', 'BIAS'])
-    _OBSERVATION_STATUSES = frozenset({ObservationStatus.READY, ObservationStatus.ONGOING})
+
+    # Note that we want to include OBSERVED observations here since this is legacy data, so most if not all observations
+    # should be marked OBSERVED and we will reset this later to READY.
+    _OBSERVATION_STATUSES = frozenset({ObservationStatus.READY, ObservationStatus.ONGOING, ObservationStatus.OBSERVED})
 
     # We contain private classes with static members for the keys in the associative
     # arrays in order to have this information defined at the top-level once.
@@ -861,7 +864,6 @@ class OcsProgramProvider(ProgramProvider):
         priority = Priority[data[OcsProgramProvider._ObsKeys.PRIORITY].upper()]
 
         # If the status is not legal, terminate parsing.
-        # *** HERE ***
         if status not in OcsProgramProvider._OBSERVATION_STATUSES:
             return None
 

--- a/scheduler/core/programprovider/ocs/__init__.py
+++ b/scheduler/core/programprovider/ocs/__init__.py
@@ -859,6 +859,10 @@ class OcsProgramProvider(ProgramProvider):
         status = ObservationStatus[data[OcsProgramProvider._ObsKeys.STATUS].upper()]
         priority = Priority[data[OcsProgramProvider._ObsKeys.PRIORITY].upper()]
 
+        # If the status is not legal, terminate parsing.
+        if status == ObservationStatus.PHASE2 or status == ObservationStatus.ON_HOLD:
+            return None
+
         setuptime_type = SetupTimeType[data[OcsProgramProvider._ObsKeys.SETUPTIME_TYPE]]
         acq_overhead = timedelta(milliseconds=data[OcsProgramProvider._ObsKeys.SETUPTIME])
 

--- a/scheduler/core/programprovider/ocs/__init__.py
+++ b/scheduler/core/programprovider/ocs/__init__.py
@@ -53,6 +53,7 @@ class OcsProgramProvider(ProgramProvider):
     _GPI_FILTER_WAVELENGTHS = {'Y': 1.05, 'J': 1.25, 'H': 1.65, 'K1': 2.05, 'K2': 2.25}
     _NIFS_FILTER_WAVELENGTHS = {'ZJ': 1.05, 'JH': 1.25, 'HK': 2.20}
     _OBSERVE_TYPES = frozenset(['FLAT', 'ARC', 'DARK', 'BIAS'])
+    _OBSERVATION_STATUSES = frozenset({ObservationStatus.READY, ObservationStatus.ONGOING})
 
     # We contain private classes with static members for the keys in the associative
     # arrays in order to have this information defined at the top-level once.
@@ -860,7 +861,8 @@ class OcsProgramProvider(ProgramProvider):
         priority = Priority[data[OcsProgramProvider._ObsKeys.PRIORITY].upper()]
 
         # If the status is not legal, terminate parsing.
-        if status == ObservationStatus.PHASE2 or status == ObservationStatus.ON_HOLD:
+        # *** HERE ***
+        if status not in OcsProgramProvider._OBSERVATION_STATUSES:
             return None
 
         setuptime_type = SetupTimeType[data[OcsProgramProvider._ObsKeys.SETUPTIME_TYPE]]


### PR DESCRIPTION
The only observations that are parsed from the JSON code in the OCS program parser are those that are:
* `READY`
* `ONGOING`
* `OBSERVED`
We want the latter since we reset all observations after they have been read into the `Collector`. Since this is past semester data, most (if not all) observations will be marked `OBSERVED`.

The `Selector` code now ignores `INACTIVE` and `OBSERVED` observations (we will be flipping some observations to INACTIVE based on program splitting with unnecessary tellurics, for example), and the `Selection` only contains `READY` and `ONGOING` observations.

This generates a slightly different plan as expected since certain observations that were formerly admitted but should not have been are now properly excluded.