### PR TITLE
Fix overlapping visit bug

### DIFF
--- a/scheduler/core/components/optimizer/greedymax.py
+++ b/scheduler/core/components/optimizer/greedymax.py
@@ -392,7 +392,7 @@ class GreedyMaxOptimizer(BaseOptimizer):
             for idx in range(max_group_info.interval[0],
                              max_group_info.interval[-1] - max_group_info.n_slots_remaining + 2):
 
-                integral_score = sum(scores[idx:idx + max_group_info.n_slots_remaining])
+                integral_score = sum(scores[idx:idx + max_group_info.n_slots_remaining + 1])
 
                 if integral_score > max_integral_score:
                     max_integral_score = integral_score
@@ -794,6 +794,9 @@ class GreedyMaxOptimizer(BaseOptimizer):
         # Write observations from the timelines to the output plan
         self.output_plans(plans)
 
+    def _length_visit(self, n_acq, n_seq):
+        return n_acq + Plan.time2slots(self.time_slot_length, n_seq)
+
     def _add_visit(self,
                    night_idx: NightIndex,
                    obs: Observation,
@@ -807,7 +810,7 @@ class GreedyMaxOptimizer(BaseOptimizer):
 
         site = max_group_info.group_data.group.observations()[0].site
         timeline = self.timelines[night_idx][site]
-        program = self.selection.program_info[max_group_info.group_data.group.program_id].program
+        # program = self.selection.program_info[max_group_info.group_data.group.program_id].program
 
         iobs = self.obs_group_ids.index(obs.to_unique_group_id)
         cumul_seq = obs.cumulative_exec_times()
@@ -819,11 +822,15 @@ class GreedyMaxOptimizer(BaseOptimizer):
 
         # type inspector cannot infer that cumul_seq[idx] is a timedelta.
         # noinspection PyTypeChecker
-        visit_length = n_slots_acq + Plan.time2slots(self.time_slot_length, cumul_seq[atom_end])
-        while n_slots_filled + visit_length <= len(best_interval) and atom_end <= len(cumul_seq) - 2:
+        # visit_length = n_slots_acq + Plan.time2slots(self.time_slot_length, cumul_seq[atom_end])
+        visit_length = self._length_visit(n_slots_acq, cumul_seq[atom_end])
+        next_atom = atom_end + 1
+        while (next_atom <= len(cumul_seq) - 1 and
+               n_slots_filled + self._length_visit(n_slots_acq, cumul_seq[next_atom]) <= len(best_interval)):
             atom_end += 1
             # noinspection PyTypeChecker
-            visit_length = n_slots_acq + Plan.time2slots(self.time_slot_length, cumul_seq[atom_end])
+            visit_length = self._length_visit(n_slots_acq, cumul_seq[atom_end])
+            next_atom = atom_end + 1
 
         n_slots_filled += visit_length
 
@@ -831,8 +838,14 @@ class GreedyMaxOptimizer(BaseOptimizer):
         start_time_slot, start = timeline.add(iobs, visit_length, best_interval)
 
         # Get visit score and store information for the output plans
-        end_time_slot = start_time_slot + visit_length
-        visit_score = sum(max_group_info.group_data.group_info.scores[night_idx][start_time_slot:end_time_slot])
+        end_time_slot = start_time_slot + visit_length - 1
+        visit_score = sum(max_group_info.group_data.group_info.scores[night_idx][start_time_slot:end_time_slot + 1])
+
+        # print(timeline)
+        # print(f'Adding {obs.to_unique_group_id.id} start_slot {start_time_slot}, end_slot {end_time_slot}, '
+        #       f'atom_end {atom_end}, last atom {len(cumul_seq) - 1}, '
+        #       f'visit_length {visit_length}, len(best_interval) {len(best_interval)}')
+        # timeline.print(self.obs_group_ids)
 
         self.obs_in_plan[site][start_time_slot] = ObsPlanData(
             obs=obs,
@@ -873,7 +886,7 @@ class GreedyMaxOptimizer(BaseOptimizer):
 
         if not timeline.is_full:
             # Find the best location in timeline for the group
-            best_interval = GreedyMaxOptimizer._find_group_position(night_idx, max_group_info)
+            best_interval = self._find_group_position(night_idx, max_group_info)
 
             if self.show_plots:
                 self._plot_interval(max_group_info.group_data.group_info.scores[night_idx], max_group_info.interval,
@@ -935,6 +948,7 @@ class GreedyMaxOptimizer(BaseOptimizer):
             # TODO: Shift to remove any gaps in the plan?
 
             # Re-score program (pseudo time accounting)
+            # print(f'Rescore {program.id}')
             self._update_score(program, night_idx=night_idx)
 
             if timeline.slots_unscheduled() <= 0:
@@ -947,6 +961,8 @@ class GreedyMaxOptimizer(BaseOptimizer):
 
     def output_plans(self, plans: Plans) -> None:
         """Write visit information from timelines to output plans, ensures chronological order"""
+
+        # print(f'output_plans')
 
         for timeline in self.timelines[plans.night_idx]:
             obs_order = timeline.get_observation_order()
@@ -962,6 +978,8 @@ class GreedyMaxOptimizer(BaseOptimizer):
 
                     # Add visit to final plan
                     obs_in_plan = self.obs_in_plan[timeline.site][start_time_slot]
+                    # print(f'{obs_in_plan.obs.id.id:20} {start_time_slot:4} {end_time_slot:4} {end_time_slot - start_time_slot + 1:4} '
+                    #       f'{obs_in_plan.obs_len:4}')
                     plans[timeline.site].add(obs_in_plan.obs,
                                              obs_in_plan.obs_start,
                                              obs_in_plan.atom_start,
@@ -970,3 +988,4 @@ class GreedyMaxOptimizer(BaseOptimizer):
                                              obs_in_plan.obs_len,
                                              obs_in_plan.visit_score)
                     plans[timeline.site].update_time_slots(timeline.slots_unscheduled())
+            print('')

--- a/scheduler/core/output/__init__.py
+++ b/scheduler/core/output/__init__.py
@@ -135,9 +135,9 @@ def print_plans(all_plans: List[Plans]) -> None:
             for visit in plan.visits:
                 start_time_str = visit.start_time.strftime('%Y-%m-%d %H:%M')
                 end_time_str = (visit.start_time + timedelta(minutes=visit.time_slots)).strftime('%Y-%m-%d %H:%M')
-                print(f'\t{start_time_str} to {end_time_str}:   {visit.obs_id.id:20} {visit.score:8.2f}  '
+                print(f'\t{start_time_str} to {end_time_str}   {visit.obs_id.id:20} {visit.score:8.2f}  '
                       f'{visit.atom_start_idx:9d}  {visit.atom_end_idx:9d}  {visit.start_time_slot:9d}  '
-                      f' {(visit.start_time_slot + visit.time_slots):9d} {visit.time_slots:9d}')
+                      f' {(visit.start_time_slot + visit.time_slots - 1):9d} {visit.time_slots:9d}')
 
 
 def plans_table(all_plans: List[Plans]) -> List[Dict[Site, DataFrame]]:

--- a/scheduler/core/programprovider/ocs/__init__.py
+++ b/scheduler/core/programprovider/ocs/__init__.py
@@ -676,7 +676,9 @@ class OcsProgramProvider(ProgramProvider):
         # Remove the None values.
         resources = frozenset([res for res in resources if res is not None])
         mode = determine_mode(instrument)
-        if instrument == 'GPI':
+        # For now we do not split NIR spectroscopy
+        if (mode != ObservationMode.IMAGING and
+                instrument in ['GPI', 'GNIRS', 'NIFS', 'IGRINS', 'Flamingos2', 'Phoenix']):
             do_not_split = True
 
         # Analyze sky offset patterns using auto-correlation


### PR DESCRIPTION
Fixes a bug in _add_visit for how the cumulative sequence length is compared with the total observation length. This fixes the overlap between visits.
Also, this prevents NIR spectroscopic observations from being split. 
Finally, there are a few bug fixes related to using index numbers vs slices.