### PR TITLE
SCHED-528: Fixing requirements.txt for validation.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ omegaconf
 fastapi
 strawberry-graphql[fastapi]
 uvicorn[standard]
-lucupy
+lucupy==0.1.57
 pytest-asyncio
 gelidum
 python-dateutil


### PR DESCRIPTION
New version of lucupy does not work with Validation mode.