### PR TITLE
GSCHED-489: updated collector time accounting

### DIFF
--- a/definitions.py
+++ b/definitions.py
@@ -6,7 +6,7 @@ import logging
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
-DEFAULT_LOGGING_LEVEL = logging.INFO
+DEFAULT_LOGGING_LEVEL = logging.ERROR
 
 # Enable this turn off logging entirely.
 # DEFAULT_LOGGING_LEVEL = None

--- a/scheduler/core/components/collector/__init__.py
+++ b/scheduler/core/components/collector/__init__.py
@@ -14,7 +14,8 @@ from lucupy import sky
 from lucupy.minimodel import (ALL_SITES, Constraints, ElevationType, NightIndex, NightIndices, NonsiderealTarget,
                               Observation, ObservationID, ObservationClass, Program, ProgramID, ProgramTypes, Semester,
                               SiderealTarget, Site, SkyBackground, Target, TimeslotIndex, QAState, ObservationStatus,
-                              Group, UniqueGroupID)
+                              Group)
+
 import numpy as np
 
 from scheduler.core.calculations import NightEvents, TargetInfo, TargetInfoMap, TargetInfoNightIndexMap
@@ -578,6 +579,7 @@ class Collector(SchedulerComponent):
                 # We process this visit.
                 # Update Observation from Collector.
                 observation = self.get_observation(visit.obs_id)
+
                 # print(f'time_accounting for visit {visit.obs_id.id}')
                 group = self._get_group(observation)
                 # if group is not None:

--- a/scheduler/scripts/run_greedymax.py
+++ b/scheduler/scripts/run_greedymax.py
@@ -9,5 +9,7 @@ from run_main import main
 if __name__ == '__main__':
     main(
         num_nights_to_schedule=3,
-        sites=ALL_SITES
+        sites=ALL_SITES,
+        test_events=True,
+        verbose=False
     )


### PR DESCRIPTION
Here is the next iteration of collector time accounting. It still needs some tweaking but it would be good to test what is here
- don't charge scheduling groups if an event occurs during the group visit (TODO: just do this if there is more than one observation in the group)
- observation not in a scheduling group will charge the atoms up to an interrupting event
- set unneeded partner calibrations (e.g. tellurics) to INACTIVE

Other TODO: add no_charged time category and charge interrupted observations to that.

Please review and clean up, but don't remove the commented-out print statements, I may need those for the next iteration.