### PR TITLE
SCHED-531: Move all time to num timeslots calculations to point to lucupy time2slots

### DIFF
--- a/scheduler/core/components/collector/__init__.py
+++ b/scheduler/core/components/collector/__init__.py
@@ -16,6 +16,7 @@ from lucupy.minimodel import (ALL_SITES, Constraints, ElevationType, NightIndex,
                               Observation, ObservationID, ObservationClass, Program, ProgramID, ProgramTypes, Semester,
                               SiderealTarget, Site, SkyBackground, Target, TimeslotIndex, QAState, ObservationStatus,
                               Group)
+from lucupy.timeutils import time2slots
 
 from scheduler.core.calculations import NightEvents, TargetInfo, TargetInfoMap, TargetInfoNightIndexMap
 from scheduler.core.components.base import SchedulerComponent
@@ -627,7 +628,7 @@ class Collector(SchedulerComponent):
                     observation = self.get_observation(visit.obs_id)
 
                     # Number of slots in acquisition
-                    n_slots_acq = Plan.time2slots(time_slot_length, observation.acq_overhead)
+                    n_slots_acq = time2slots(time_slot_length, observation.acq_overhead)
                     # print(f'\t\t{observation.acq_overhead.total_seconds()} {n_slots_acq}')
 
                     # Cumulative exec_times of unobserved atoms
@@ -646,7 +647,7 @@ class Collector(SchedulerComponent):
                     # Loop over atoms
                     for atom_idx in range(visit.atom_start_idx, visit.atom_end_idx + 1):
                         # calculate end time slot for each atom and compare with end_timeslot_charge
-                        slot_length_visit = n_slots_acq + Plan.time2slots(time_slot_length, cumul_seq[atom_idx])  # noqa
+                        slot_length_visit = n_slots_acq + time2slots(time_slot_length, cumul_seq[atom_idx])  # noqa
                         slot_atom_end = visit.start_time_slot + slot_length_visit - 1
 
                         # Not currently in use.

--- a/scheduler/core/components/collector/__init__.py
+++ b/scheduler/core/components/collector/__init__.py
@@ -654,7 +654,7 @@ class Collector(SchedulerComponent):
                         # if atom_idx == visit.atom_start_idx:
                         #     slot_atom_length = slot_length_visit
                         # else:
-                        #     time_slots = Plan.time2slots(time_slot_length, cumul_seq[atom_idx-1])  # noqa
+                        #     time_slots = time2slots(time_slot_length, cumul_seq[atom_idx-1])  # noqa
                         #     slot_atom_length = slot_length_visit - n_slots_acq - time_slots
                         # if slot_atom_length > 0:
                         #     slot_atom_start = slot_atom_end - slot_atom_length + 1

--- a/scheduler/core/components/optimizer/dummy.py
+++ b/scheduler/core/components/optimizer/dummy.py
@@ -7,6 +7,7 @@ import random
 from datetime import datetime
 from typing import Optional, Tuple
 
+from lucupy.timeutils import time2slots
 from lucupy.types import Interval
 
 from scheduler.core.calculations import GroupData
@@ -59,7 +60,7 @@ class DummyOptimizer(BaseOptimizer):
         for observation in group.group.observations():
             plan = plans[observation.site]
             if not plan.is_full and plan.site == observation.site:
-                obs_len = plan.time2slots(plan.time_slot_length, observation.exec_time())
+                obs_len = time2slots(plan.time_slot_length, observation.exec_time())
                 if plan.time_left() >= obs_len and observation not in plan:
                     atom_start = 0
                     atom_end = len(observation.sequence) - 1

--- a/scheduler/core/components/optimizer/greedymax.py
+++ b/scheduler/core/components/optimizer/greedymax.py
@@ -13,6 +13,7 @@ import numpy.typing as npt
 from lucupy.minimodel import (NIR_INSTRUMENTS, Group, NightIndex, Observation, ObservationClass, ObservationID,
                               ObservationStatus, Program, QAState, Site, UniqueGroupID, Wavelengths, ObservationMode)
 from lucupy.minimodel.resource import Resource
+from lucupy.timeutils import time2slots
 from lucupy.types import Interval, ZeroTime
 
 from scheduler.core.calculations import GroupData, NightTimeslotScores
@@ -223,7 +224,7 @@ class GreedyMaxOptimizer(BaseOptimizer):
         """
 
         # the number of time slots in the minimum visit length
-        n_slots_min_visit = int(np.ceil(self.min_visit_len / self.time_slot_length))
+        n_slots_min_visit = time2slots(self.time_slot_length, self.min_visit_len)
         # print(f"n_min_visit: {n_min_visit}")
 
         # Calculate the remaining clock time necessary for the group to be complete.
@@ -233,10 +234,9 @@ class GreedyMaxOptimizer(BaseOptimizer):
         time_remaining, time_remaining_min, exec_sci_nir, n_std = self._exec_time_remaining(group)
 
         # Calculate the number of time slots needed to complete the group.
-        # n_slots_remaining = int(np.ceil((time_remaining / self.time_slot_length)))  # number of time slots
-        # This use of time2slots works but is probably not kosher, need to make this more general
-        n_slots_remaining = Plan.time2slots(self.time_slot_length, time_remaining)
-        n_slots_remaining_min = Plan.time2slots(self.time_slot_length, time_remaining_min)
+        # This use of time2slots works but is probably not kosher, need to make this more general.
+        n_slots_remaining = time2slots(self.time_slot_length, time_remaining)
+        n_slots_remaining_min = time2slots(self.time_slot_length, time_remaining_min)
 
         # Time slots corresponding to the max of minimum time remaining and the minimum visit length
         # This supports long observations than cannot be split. helps prevent splitting into very small pieces
@@ -432,8 +432,7 @@ class GreedyMaxOptimizer(BaseOptimizer):
 
         # This repeats the calculation from find_max_group, pass this instead?
         # time_remaining = group_data.group.exec_time() - group_data.group.total_used()  # clock time
-        # This is the same as time2slots, need to make that more generally available
-        # n_time_remaining = int(np.ceil((time_remaining / self.time_slot_length)))  # number of time slots
+        # n_time_remaining = time2slots(self.time_slot_length, time_remaining)  # number of time slots
         # n_min, n_slots_remaining = self._min_slots_remaining(max_group_info.group_data.group)
 
         if max_group_info.n_slots_remaining < len(max_group_info.interval):
@@ -462,13 +461,13 @@ class GreedyMaxOptimizer(BaseOptimizer):
             atom_start = self._first_nonzero_time_idx(cumul_seq)
             atom_end = atom_start
 
-            n_slots_acq = Plan.time2slots(self.time_slot_length, obs.acq_overhead)
-            visit_length = n_slots_acq + Plan.time2slots(self.time_slot_length,
-                                                         cumul_seq[atom_end])
+            n_slots_acq = time2slots(self.time_slot_length, obs.acq_overhead)
+            visit_length = n_slots_acq + time2slots(self.time_slot_length, cumul_seq[atom_end])
+
             # TODO: can this be done w/o a loop? convert cumm_seq to slots, and find the value that fits
             while n_slots_filled + visit_length <= len_interval and atom_end <= len(cumul_seq) - 2:
                 atom_end += 1
-                visit_length = n_slots_acq + Plan.time2slots(self.time_slot_length, cumul_seq[atom_end])
+                visit_length = n_slots_acq + time2slots(self.time_slot_length, cumul_seq[atom_end])
 
             slot_end = slot_start + visit_length - 1
             # NIR science time for to determine the number of tellurics
@@ -519,8 +518,8 @@ class GreedyMaxOptimizer(BaseOptimizer):
         # TODO: Check scores to confirm that the observations are scheduleable (?)
         for partcal_obs in partner_obs:
             # Need the length of the calibration sequence only
-            n_slots_cal = Plan.time2slots(self.time_slot_length, partcal_obs.exec_time())
-            n_slots_acq = Plan.time2slots(self.time_slot_length, partcal_obs.acq_overhead)
+            n_slots_cal = time2slots(self.time_slot_length, partcal_obs.exec_time())
+            n_slots_acq = time2slots(self.time_slot_length, partcal_obs.acq_overhead)
 
             # Try std first
             # Mean std airmass
@@ -795,7 +794,7 @@ class GreedyMaxOptimizer(BaseOptimizer):
         self.output_plans(plans)
 
     def _length_visit(self, n_acq, n_seq):
-        return n_acq + Plan.time2slots(self.time_slot_length, n_seq)
+        return n_acq + time2slots(self.time_slot_length, n_seq)
 
     def _add_visit(self,
                    night_idx: NightIndex,
@@ -818,7 +817,7 @@ class GreedyMaxOptimizer(BaseOptimizer):
         atom_start = self._first_nonzero_time_idx(cumul_seq)
         atom_end = atom_start
 
-        n_slots_acq = Plan.time2slots(self.time_slot_length, obs.acq_overhead)
+        n_slots_acq = time2slots(self.time_slot_length, obs.acq_overhead)
 
         # type inspector cannot infer that cumul_seq[idx] is a timedelta.
         # noinspection PyTypeChecker
@@ -910,7 +909,7 @@ class GreedyMaxOptimizer(BaseOptimizer):
                     standards, place_before = self.place_standards(night_idx, best_interval, prog_obs, part_obs,
                                                                    max_group_info.n_std)
                     for ii, std in enumerate(standards):
-                        n_slots_cal += Plan.time2slots(self.time_slot_length, std.exec_time())
+                        n_slots_cal += time2slots(self.time_slot_length, std.exec_time())
                         # print(f"{std.id.id} {place_before[ii]} {n_slots_cal}")
                         if place_before[ii]:
                             before_std = std
@@ -933,7 +932,7 @@ class GreedyMaxOptimizer(BaseOptimizer):
                 n_slots_filled = self._add_visit(night_idx, obs, max_group_info, best_interval, n_slots_filled)
                 if after_std is not None:
                     # "put back" time for the final standard
-                    n_slots_filled -= Plan.time2slots(self.time_slot_length, standards[-1].exec_time())
+                    n_slots_filled -= time2slots(self.time_slot_length, standards[-1].exec_time())
 
             if after_std is not None:
                 obs = after_std

--- a/scheduler/core/components/optimizer/greedymax.py
+++ b/scheduler/core/components/optimizer/greedymax.py
@@ -821,7 +821,7 @@ class GreedyMaxOptimizer(BaseOptimizer):
 
         # type inspector cannot infer that cumul_seq[idx] is a timedelta.
         # noinspection PyTypeChecker
-        # visit_length = n_slots_acq + Plan.time2slots(self.time_slot_length, cumul_seq[atom_end])
+        # visit_length = n_slots_acq + time2slots(self.time_slot_length, cumul_seq[atom_end])
         visit_length = self._length_visit(n_slots_acq, cumul_seq[atom_end])
         next_atom = atom_end + 1
         while (next_atom <= len(cumul_seq) - 1 and

--- a/scheduler/core/eventsqueue/events.py
+++ b/scheduler/core/eventsqueue/events.py
@@ -4,10 +4,10 @@
 from abc import ABC
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from math import ceil
 from typing import final, FrozenSet, Optional
 
 from lucupy.minimodel import Resource, Conditions, Site, TimeslotIndex
+from lucupy.timeutils import time2slots
 
 
 @dataclass
@@ -25,7 +25,7 @@ class Event(ABC):
         This would typically be the twilight of the night on which the event occurs, hence the name twi_eve_time.
         """
         time_from_twilight = self.start - twi_eve_time
-        time_slots_from_twilight = ceil(time_from_twilight / time_slot_length)
+        time_slots_from_twilight = time2slots(time_slot_length, time_from_twilight)
         return TimeslotIndex(time_slots_from_twilight)
 
 


### PR DESCRIPTION
As pointed out by @stroncod, the logic to convert a time quantity to number of time slots was repeated throughout the code base. This method has no inherent tie to `Plan`, where it was included before, and the logic has been moved to lucupy and all of the implementations (and other calculations in the code that calculate this explicitly) now point there.

**NOTE:** This requires an update to lucupy 0.1.59.