### PR TITLE
SCHED-532: RankerParameters should not be ClassVars and should be initialized with default_factory.

### DIFF
--- a/scheduler/core/components/ranker/default.py
+++ b/scheduler/core/components/ranker/default.py
@@ -44,11 +44,6 @@ class RankerParameters:
     score_combiner: Callable[[npt.NDArray[float]], npt.NDArray[float]] = _default_score_combiner
 
 
-# Set the class-shared variables in the RankerParameters to immutable.
-RankerParameters.dec_diff_less_40.setflags(write=False)
-RankerParameters.dec_diff.setflags(write=False)
-
-
 @final
 @dataclass(frozen=True)
 class RankerBandParameters:

--- a/scheduler/core/components/ranker/default.py
+++ b/scheduler/core/components/ranker/default.py
@@ -37,9 +37,9 @@ class RankerParameters:
     wha_power: Final[float] = 1.0
 
     # Weighted to slightly positive HA.
-    dec_diff_less_40: ClassVar[npt.NDArray[float]] = field(default=np.array([3., 0., -0.08]))
+    dec_diff_less_40: npt.NDArray[float] = field(default_factory=lambda: np.array([3., 0., -0.08]))
     # Weighted to 0 HA if Xmin > 1.3.
-    dec_diff: ClassVar[npt.NDArray[float]] = field(default=np.array([3., 0.1, -0.06]))
+    dec_diff: npt.NDArray[float] = field(default_factory=lambda: np.array([3., 0.1, -0.06]))
 
     score_combiner: Callable[[npt.NDArray[float]], npt.NDArray[float]] = _default_score_combiner
 


### PR DESCRIPTION
Since these should be settable by users, they should not be `ClassVar`, and looking forward to possible uses of future versions of Python, should be initialized by `default` but by `default_factory`.

They should also not be frozen as numpy arrays.