### PR TITLE
SCHED-547: Fixing bugs in plan assembly when there are no scheduled visits.

### DIFF
--- a/demo/run_validation.ipynb
+++ b/demo/run_validation.ipynb
@@ -2,11 +2,11 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-10-26T23:54:02.959513Z",
-     "start_time": "2023-10-26T23:54:02.948170Z"
+     "end_time": "2023-12-28T03:27:19.723344Z",
+     "start_time": "2023-12-28T03:27:19.713460Z"
     }
    },
    "outputs": [],
@@ -18,14 +18,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-10-26T23:54:04.578459Z",
-     "start_time": "2023-10-26T23:54:04.572010Z"
+     "end_time": "2023-12-28T03:27:19.801868Z",
+     "start_time": "2023-12-28T03:27:19.728856Z"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'mercury'",
+     "output_type": "error",
+     "traceback": [
+      "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
+      "\u001B[0;31mModuleNotFoundError\u001B[0m                       Traceback (most recent call last)",
+      "\u001B[0;32m<ipython-input-2-1022b08fce20>\u001B[0m in \u001B[0;36m<module>\u001B[0;34m\u001B[0m\n\u001B[0;32m----> 1\u001B[0;31m \u001B[0;32mimport\u001B[0m \u001B[0mmercury\u001B[0m \u001B[0;32mas\u001B[0m \u001B[0mmr\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m\u001B[1;32m      2\u001B[0m \u001B[0;32mimport\u001B[0m \u001B[0mpandas\u001B[0m \u001B[0;32mas\u001B[0m \u001B[0mpd\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m      3\u001B[0m \u001B[0;32mfrom\u001B[0m \u001B[0mIPython\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mdisplay\u001B[0m \u001B[0;32mimport\u001B[0m \u001B[0mdisplay\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m      4\u001B[0m \u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m      5\u001B[0m \u001B[0;32mfrom\u001B[0m \u001B[0mastropy\u001B[0m\u001B[0;34m.\u001B[0m\u001B[0mtime\u001B[0m \u001B[0;32mimport\u001B[0m \u001B[0mTime\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0mTimeDelta\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n",
+      "\u001B[0;31mModuleNotFoundError\u001B[0m: No module named 'mercury'"
+     ]
+    }
+   ],
    "source": [
     "%%capture\n",
     "import mercury as mr\n",
@@ -41,7 +53,7 @@
     "\n",
     "from definitions import ROOT_DIR\n",
     "from scheduler.core.builder.blueprint import CollectorBlueprint, OptimizerBlueprint\n",
-    "from scheduler.core.builder.builder import ValidationBuilder\n",
+    "from scheduler.core.builder.validationbuilder import ValidationBuilder\n",
     "from scheduler.core.components.collector import *\n",
     "from scheduler.core.output import (print_collector_info, plans_table, pickle_plans, pickle_selection)\n",
     "from scheduler.core.programprovider.ocs import read_ocs_zipfile, OcsProgramProvider\n",
@@ -50,11 +62,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-10-26T23:54:05.849502Z",
-     "start_time": "2023-10-26T23:54:05.651790Z"
+     "end_time": "2023-12-28T03:27:19.813487Z",
+     "start_time": "2023-12-28T03:27:19.805341Z"
     }
    },
    "outputs": [
@@ -62,17 +74,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/Users/sraaphorst/Development/SchedulerRepos/validation/scheduler/demo\n"
+      "/Users/sraaphorst/Development/SchedulerRepos/scheduler/demo\n"
      ]
     },
     {
-     "data": {
-      "text/plain": "mercury.App",
-      "text/html": "<h3>Mercury Application</h3><small>This output won't appear in the web app.</small>",
-      "application/mercury+json": "{\n    \"widget\": \"App\",\n    \"title\": \"Scheduler Validation Test\",\n    \"description\": \"Try the Validation mode for the Scheduler\",\n    \"show_code\": false,\n    \"show_prompt\": true,\n    \"output\": \"app\",\n    \"schedule\": \"\",\n    \"notify\": \"{}\",\n    \"continuous_update\": false,\n    \"static_notebook\": false,\n    \"show_sidebar\": true,\n    \"full_screen\": true,\n    \"allow_download\": true,\n    \"stop_on_error\": false,\n    \"model_id\": \"mercury-app\",\n    \"code_uid\": \"App.0.40.25.10-randebe0fad8\"\n}"
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     "ename": "NameError",
+     "evalue": "name 'TimeDelta' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
+      "\u001B[0;31mNameError\u001B[0m                                 Traceback (most recent call last)",
+      "\u001B[0;32m<ipython-input-3-9476547ee090>\u001B[0m in \u001B[0;36m<module>\u001B[0;34m\u001B[0m\n\u001B[1;32m      5\u001B[0m \u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m      6\u001B[0m \u001B[0;31m# Create a fixed representation of one day.\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0;32m----> 7\u001B[0;31m \u001B[0mday\u001B[0m \u001B[0;34m=\u001B[0m \u001B[0mTimeDelta\u001B[0m\u001B[0;34m(\u001B[0m\u001B[0;36m1.0\u001B[0m\u001B[0;34m,\u001B[0m \u001B[0mformat\u001B[0m\u001B[0;34m=\u001B[0m\u001B[0;34m'jd'\u001B[0m\u001B[0;34m)\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n\u001B[0m\u001B[1;32m      8\u001B[0m \u001B[0;34m\u001B[0m\u001B[0m\n\u001B[1;32m      9\u001B[0m \u001B[0;31m# Application parameters.\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0;34m\u001B[0m\u001B[0m\n",
+      "\u001B[0;31mNameError\u001B[0m: name 'TimeDelta' is not defined"
+     ]
     }
    ],
    "source": [
@@ -98,35 +112,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-10-24T22:45:21.114196Z",
-     "start_time": "2023-10-24T22:45:21.077031Z"
+     "start_time": "2023-12-28T03:27:19.817736Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "application/mercury+json": "{\n    \"widget\": \"OutputDir\",\n    \"model_id\": \"output-dir\",\n    \"code_uid\": \"OutputDir.0.40.18.1-rand0d47a6f9\"\n}",
-      "text/html": [
-       "<h3>Output Directory</h3><small>This output won't appear in the web app.</small>"
-      ],
-      "text/plain": [
-       "mercury.OutputDir"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Output directory path: .\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "out_dir = mr.OutputDir()\n",
     "print(f\"Output directory path: {out_dir.path}\")"
@@ -134,105 +126,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-10-24T22:45:23.119030Z",
-     "start_time": "2023-10-24T22:45:22.969307Z"
+     "end_time": "2023-12-28T03:27:19.822396Z",
+     "start_time": "2023-12-28T03:27:19.820700Z"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "application/mercury+json": "{\n    \"widget\": \"Text\",\n    \"value\": \"2018-10-01\",\n    \"rows\": 1,\n    \"label\": \"Start Date\",\n    \"model_id\": \"6004504f4446492c98f4277c86890729\",\n    \"code_uid\": \"Text.0.40.15.2-rand25a5b475\",\n    \"url_key\": \"\",\n    \"disabled\": false,\n    \"hidden\": false\n}",
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6004504f4446492c98f4277c86890729",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "mercury.Text"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/mercury+json": "{\n    \"widget\": \"Numeric\",\n    \"value\": 1.0,\n    \"min\": 1.0,\n    \"max\": 10.0,\n    \"step\": 1.0,\n    \"label\": \"Nights to Schedule\",\n    \"model_id\": \"fba58620b3464246bd4ebc5d3a8c427d\",\n    \"code_uid\": \"Numeric.0.40.26.3-randdf84fb06\",\n    \"url_key\": \"\",\n    \"disabled\": false,\n    \"hidden\": false\n}",
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fba58620b3464246bd4ebc5d3a8c427d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "mercury.Numeric"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/mercury+json": "{\n    \"widget\": \"Numeric\",\n    \"value\": 1.0,\n    \"min\": 1.0,\n    \"max\": 10.0,\n    \"step\": 1.0,\n    \"label\": \"Nights for Visibility Calculations\",\n    \"model_id\": \"55d750696c374e27ab6fb89b620e1fc5\",\n    \"code_uid\": \"Numeric.0.40.26.4-randaab95b50\",\n    \"url_key\": \"\",\n    \"disabled\": false,\n    \"hidden\": false\n}",
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "55d750696c374e27ab6fb89b620e1fc5",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "mercury.Numeric"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/mercury+json": "{\n    \"widget\": \"MultiSelect\",\n    \"value\": [\n        \"GN\",\n        \"GS\"\n    ],\n    \"choices\": [\n        \"GN\",\n        \"GS\"\n    ],\n    \"label\": \"Sites\",\n    \"model_id\": \"75aa1140221d49d8bc1f02bd6c0d0863\",\n    \"code_uid\": \"MultiSelect.0.40.16.7-rand43021024\",\n    \"url_key\": \"\",\n    \"disabled\": false,\n    \"hidden\": false\n}",
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "75aa1140221d49d8bc1f02bd6c0d0863",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "mercury.MultiSelect"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/mercury+json": "{\n    \"widget\": \"Select\",\n    \"value\": \"CC50\",\n    \"choices\": [\n        \"CC50\",\n        \"CC70\",\n        \"CC80\",\n        \"CCANY\"\n    ],\n    \"label\": \"Cloud Cover\",\n    \"model_id\": \"19387fda50554e46a07d27f3083f605d\",\n    \"code_uid\": \"Select.0.40.16.12-rand8add3bad\",\n    \"url_key\": \"\",\n    \"disabled\": false,\n    \"hidden\": false\n}",
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "19387fda50554e46a07d27f3083f605d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "mercury.Select"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/mercury+json": "{\n    \"widget\": \"Select\",\n    \"value\": \"IQ70\",\n    \"choices\": [\n        \"IQ20\",\n        \"IQ70\",\n        \"IQ85\",\n        \"IQANY\"\n    ],\n    \"label\": \"Image Quality\",\n    \"model_id\": \"e9d9a5b3481c4262acb2a6973fc3514c\",\n    \"code_uid\": \"Select.0.40.16.17-rand034dcb4e\",\n    \"url_key\": \"\",\n    \"disabled\": false,\n    \"hidden\": false\n}",
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e9d9a5b3481c4262acb2a6973fc3514c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "mercury.Select"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Set up the UI.\n",
     "start_date = mr.Text(label='Start Date', value='2018-10-01')\n",
@@ -373,14 +274,6 @@
     "    semesters=frozenset([Semester(2018, SemesterHalf.B)]),\n",
     "    blueprint=collector_blueprint\n",
     ")\n",
-    "# Create the Collector and load the programs.\n",
-    "collector.load_programs(program_provider_class=OcsProgramProvider,\n",
-    "                        data=programs)\n",
-    "\n",
-    "ValidationBuilder.update_collector(collector)  # ZeroTime observations\n",
-    "\n",
-    "\n",
-    "print_collector_info(collector, samples=10)\n",
     "\n",
     "selector = builder.build_selector(collector,\n",
     "                                  num_nights_to_schedule=params.num_nights_to_schedule,\n",

--- a/scheduler/core/output/__init__.py
+++ b/scheduler/core/output/__init__.py
@@ -116,17 +116,18 @@ def print_plans(all_plans: List[Plans]) -> None:
     for plans in all_plans:
         print(f'\n\n+++++ NIGHT {plans.night_idx + 1} +++++')
         for plan in sorted(plans, key=lambda x: x.site.name):
-            print(f'Plan for site: {plan.site.name}')
-            # Print header information
-            max_score_length = max(len(f'{visit.score:8.2f}') for visit in plan.visits)
-            print(f'\t{"Execution time":{36}}    {"ObsID":{20}} {"Score":>{max_score_length}}'
-                  '  StartAtom    EndAtom  StartSlot    EndSlot   NumSlots')
-            for visit in plan.visits:
-                start_time_str = visit.start_time.strftime('%Y-%m-%d %H:%M')
-                end_time_str = (visit.start_time + timedelta(minutes=visit.time_slots)).strftime('%Y-%m-%d %H:%M')
-                print(f'\t{start_time_str} to {end_time_str}   {visit.obs_id.id:20} {visit.score:8.2f}  '
-                      f'{visit.atom_start_idx:9d}  {visit.atom_end_idx:9d}  {visit.start_time_slot:9d}  '
-                      f' {(visit.start_time_slot + visit.time_slots - 1):9d} {visit.time_slots:9d}')
+            if max_score_length := max((len(f'{visit.score:8.2f}') for visit in plan.visits), default=0):
+                print(f'Plan for site: {plan.site.name}')
+                print(f'\t{"Execution time":{36}}    {"ObsID":{20}} {"Score":>{max_score_length}}'
+                      '  StartAtom    EndAtom  StartSlot    EndSlot   NumSlots')
+                for visit in plan.visits:
+                    start_time_str = visit.start_time.strftime('%Y-%m-%d %H:%M')
+                    end_time_str = (visit.start_time + timedelta(minutes=visit.time_slots)).strftime('%Y-%m-%d %H:%M')
+                    print(f'\t{start_time_str} to {end_time_str}   {visit.obs_id.id:20} {visit.score:8.2f}  '
+                          f'{visit.atom_start_idx:9d}  {visit.atom_end_idx:9d}  {visit.start_time_slot:9d}  '
+                          f' {(visit.start_time_slot + visit.time_slots - 1):9d} {visit.time_slots:9d}')
+            else:
+                print(f'Empty plan for site: {plan.site.name}')
 
 
 def plans_table(all_plans: List[Plans]) -> List[Dict[Site, DataFrame]]:


### PR DESCRIPTION
When an event occurred and there were no `Visit`s in the plan, the code would crash due to an `IndexError` exception trying to access `partial_plan.visits[-1]`. This PR fixes this and provides clearer documentation as to what is happening.

It also fixes bugs in output when there are empty plans (i.e. providing a default value to the `max` function if a generator is empty), and more clearly indicates that there is no plan for a site for a given night when the plan is empty.

This also fixes some minor bugs and renames `try_scheduler.ipynb` to `run_validation.ipynb` for clarity.