### PR TITLE
Add check for environmental variable to set the logging level.

### DIFF
--- a/definitions.py
+++ b/definitions.py
@@ -25,3 +25,8 @@ if len(sys.argv) == 2:
         DEFAULT_LOGGING_LEVEL = LoggingLevels[sys.argv[1].upper()]
     except KeyError:
         ...
+else:
+    try:
+        DEFAULT_LOGGING_LEVEL = LoggingLevels[os.environ['SCHEDULER_DEBUGGING'].upper()]
+    except KeyError:
+        ...


### PR DESCRIPTION
To set logging level
1) check command line parameter
2) else look for SCHEDULER_DEBUGGING environmental variable
The latter works with Jupyter notebooks.