### PR TITLE
SCHED-602: Fix group selection

### DIFF
--- a/scheduler/core/components/selector/__init__.py
+++ b/scheduler/core/components/selector/__init__.py
@@ -3,6 +3,7 @@
 
 from copy import copy, deepcopy
 from dataclasses import dataclass, field
+from functools import reduce
 from typing import ClassVar, Dict, FrozenSet, KeysView, Optional, Set, final
 
 import astropy.units as u
@@ -154,6 +155,8 @@ class Selector(SchedulerComponent):
             if original_program is None:
                 logger.error(f'Program {program_id} was not found in the Collector.')
                 continue
+            if original_program.id.id == 'GN-2018B-Q-104':
+                print('Starting GN-2018B-Q-104')
 
             # We make a deep copy of the Program to work with to not change the Program in the Collector.
             # This will allow us to use the members of this deep copy for things like internal time accounting
@@ -203,6 +206,8 @@ class Selector(SchedulerComponent):
         Otherwise, the data is bundled in a ProgramCalculations object.
         """
         # The night_indices in the Selector must be a subset of the Ranker.
+        if program.id.id == 'GN-201BB-Q-104':
+            print("_calculate_program: GN-2018B-Q-104")
         night_indices_set = set(night_indices)
         if not night_indices_set.issubset(ranker.night_indices):
             ranker_night_indices = set(ranker.night_indices)
@@ -227,10 +232,29 @@ class Selector(SchedulerComponent):
                                                           night_configurations,
                                                           ranker)
 
+        if program.id.id == 'GN-2018B-Q-104':
+            temp_dict = {}
+            print('Calculated unfiltered_group_data_map.')
+            for gp_id, gp_data in unfiltered_group_data_map.items():
+                print(f'* Checking {gp_id} schedulable slot indices.')
+                for index in gp_data.group_info.schedulable_slot_indices.values():
+                    empty = index.size == 0
+                    print(f'\tindex: {index}')
+                    print(f'\tlen(index) = {len(index)}')
+                    print(f'\tempty: {empty}')
+                    if not empty:
+                        temp_dict[gp_id] = gp_data
+            print('DONE.')
+
         # We want to check if there are any time slots where a group can be scheduled: otherwise, we omit it.
         group_data_map = {gp_id: gp_data for gp_id, gp_data in unfiltered_group_data_map.items()
-                          if any(len(indices) > 0 for indices in gp_data.group_info.schedulable_slot_indices.values())}
-
+                          if any(indices.size > 0 for indices in gp_data.group_info.schedulable_slot_indices.values())
+                          and gp_data.group.id != ROOT_GROUP_ID}
+        print('*** IDS ***')
+        for key in group_data_map:
+            print(f'\t {key.id}')
+        if program.id.id == 'GN-2018B-Q-104':
+            print('Calculated group_data_map from unfiltered_group_data_map.')
         # In an observation group, the only child is an Observation:
         # hence, references here to group.children are simply the Observation.
         observations = {group_data.group.children.id: group_data.group.children
@@ -482,6 +506,8 @@ class Selector(SchedulerComponent):
         Calculate the GroupInfo for an AND group that contains subgroups and add it to
         the group_data_map.
         """
+        if program.id.id == 'GN-2018B-Q-104':
+            print(f'_calculate_and_group: {group.unique_id}')
         if not isinstance(group, AndGroup):
             raise ValueError(f'Tried to process group {group.id} as an AND group.')
         if isinstance(group.children, Observation):
@@ -501,13 +527,21 @@ class Selector(SchedulerComponent):
 
         # TODO: Confirm that this is correct behavior.
         # Make sure that there is an entry for each subgroup. If not, we skip.
+        if program.id.id == 'GN-2018B-Q-104':
+            print(f'checking subgroups for: {group.unique_id}')
         if any(sg.unique_id not in group_data_map for sg in group.children):
+            if program.id.id == 'GN-2018B-Q-104':
+                print(f'subgroups for {group.unique_id} not all in group_data_map')
             # We don't include the root group for scheduling, so if it is missing children, we don't output a warning.
             if group.id != ROOT_GROUP_ID:
+                if program.id.id == 'GN-2018B-Q-104':
+                    print(f'subgroup {group.unique_id} is not ROOT_GROUP')
                 missing_subgroups = [sg.unique_id.id for sg in group.children if sg.unique_id not in group_data_map]
                 missing_str = ', '.join(missing_subgroups)
-                logger.warning(f'Selector skipping group {group.unique_id}: scores missing for children: '
-                               f'{missing_str}.')
+                # logger.warning(f'Selector skipping group {group.unique_id}: scores missing for children: '
+                #                f'{missing_str}.')
+                if program.id.id == 'GN-2018B-Q-104':
+                    print(f'missing data for children: {missing_str}... skipping')
             return group_data_map
 
         # Calculate the most restrictive conditions.
@@ -554,6 +588,9 @@ class Selector(SchedulerComponent):
                 group_data_map[sg.unique_id].group_info.schedulable_slot_indices[night_idx]
                 for sg in group.children
             ]))
+            # np.array([reduce(np.intersect1d,
+            #                  [group_data_map[sg.unique_id].group_info.schedulable_slot_indices[night_idx]
+            #                   for sg in group.children])])
             for night_idx in night_indices
         }
 
@@ -570,7 +607,6 @@ class Selector(SchedulerComponent):
             schedulable_slot_indices=schedulable_slot_indices,
             scores=scores
         )
-
         group_data_map[group.unique_id] = GroupData(group, group_info)
         return group_data_map
 

--- a/scheduler/scripts/run_main.py
+++ b/scheduler/scripts/run_main.py
@@ -277,32 +277,6 @@ def main(*,
                                                                                 for night_idx in night_indices}},
                                                     ranker=ranker)
 
-                        # print('*** SELECTION ***')
-                        # for p in selection.program_info.values():
-                        #     print(f'Program: {p.program.id.id}')
-                        #     for k, g in p.group_data_map.items():
-                        #         print(f'Looking at {k.id}.')
-                        #         # The 'root' check is a workaround'
-                        #         print(f'\t Group: uiq={g.group.unique_id.id} obs={g.group.is_observation_group()} '
-                        #               f'sched={g.group.is_scheduling_group()} and={g.group.is_and_group()}')
-                        #         print(f'\t Night: {night_idx}, score num: {len(g.group_info.scores)}')
-                        #         print(f'\t Scores: {g.group_info.scores}')
-                        #         print(f'\t\t Max score: {np.max(g.group_info.scores[0])}')
-                        #         if 'root' in g.group.unique_id.id:
-                        #             print('HERE')
-                        #         if g.group.is_scheduling_group():
-                        #             for subgroup in g.group.children:
-                        #                 sg = p.group_data_map[subgroup.unique_id]
-                        #                 print(f'\t\t {subgroup.unique_id.id} {subgroup.exec_time()} {subgroup.is_observation_group()} {np.max(sg.group_info.scores[0]):7.2f}')
-                        #                 # print(g.group.children)
-                        #                 for obs in subgroup.observations():
-                        #                     print(
-                        #                         f'\t\t\t Obs: {obs.id.id} {obs.exec_time()} {obs.obs_class.name:12} {obs.total_used()} ' \
-                        #                         f'{obs.status.name} {min(p.target_info[obs.id][0].airmass):5.2f}')
-                        #                     for target in obs.targets:
-                        #                         print(f'\t\t\t\t {target.name} {target.type} {target.ra}')
-                        # print('*** SELECTION DONE ***')
-
                         # Right now the optimizer generates List[Plans], a list of plans indexed by
                         # every night in the selection. We only want the first one, which corresponds
                         # to the current night index we are looping over.

--- a/scheduler/scripts/run_main.py
+++ b/scheduler/scripts/run_main.py
@@ -277,6 +277,32 @@ def main(*,
                                                                                 for night_idx in night_indices}},
                                                     ranker=ranker)
 
+                        # print('*** SELECTION ***')
+                        # for p in selection.program_info.values():
+                        #     print(f'Program: {p.program.id.id}')
+                        #     for k, g in p.group_data_map.items():
+                        #         print(f'Looking at {k.id}.')
+                        #         # The 'root' check is a workaround'
+                        #         print(f'\t Group: uiq={g.group.unique_id.id} obs={g.group.is_observation_group()} '
+                        #               f'sched={g.group.is_scheduling_group()} and={g.group.is_and_group()}')
+                        #         print(f'\t Night: {night_idx}, score num: {len(g.group_info.scores)}')
+                        #         print(f'\t Scores: {g.group_info.scores}')
+                        #         print(f'\t\t Max score: {np.max(g.group_info.scores[0])}')
+                        #         if 'root' in g.group.unique_id.id:
+                        #             print('HERE')
+                        #         if g.group.is_scheduling_group():
+                        #             for subgroup in g.group.children:
+                        #                 sg = p.group_data_map[subgroup.unique_id]
+                        #                 print(f'\t\t {subgroup.unique_id.id} {subgroup.exec_time()} {subgroup.is_observation_group()} {np.max(sg.group_info.scores[0]):7.2f}')
+                        #                 # print(g.group.children)
+                        #                 for obs in subgroup.observations():
+                        #                     print(
+                        #                         f'\t\t\t Obs: {obs.id.id} {obs.exec_time()} {obs.obs_class.name:12} {obs.total_used()} ' \
+                        #                         f'{obs.status.name} {min(p.target_info[obs.id][0].airmass):5.2f}')
+                        #                     for target in obs.targets:
+                        #                         print(f'\t\t\t\t {target.name} {target.type} {target.ra}')
+                        # print('*** SELECTION DONE ***')
+
                         # Right now the optimizer generates List[Plans], a list of plans indexed by
                         # every night in the selection. We only want the first one, which corresponds
                         # to the current night index we are looping over.


### PR DESCRIPTION
Previously, we were performing group filtering using `len(indices)` when for numpy to act correctly, we should have been using `indices.size`.

We also now explicitly filter out the root group.