### PR TITLE
SCHED-605: Filter out programs that are out of time

### DIFF
--- a/scheduler/config.yaml
+++ b/scheduler/config.yaml
@@ -8,7 +8,7 @@ optimizer:
 
 selector:
   buffer_type: FLAT_MINUTES
-  buffer_amount: 30
+  buffer_amount: 30.0
   
 server:
   port: 8000

--- a/scheduler/config.yaml
+++ b/scheduler/config.yaml
@@ -6,6 +6,10 @@ collector:
 optimizer:
   name: GREEDYMAX
 
+selector:
+  buffer_type: FLAT_MINUTES
+  buffer_amount: 30
+  
 server:
   port: 8000
   host: 0.0.0.0

--- a/scheduler/core/builder/blueprint.py
+++ b/scheduler/core/builder/blueprint.py
@@ -3,6 +3,7 @@
 
 from typing import Any, FrozenSet, List, Type
 from enum import Enum
+from typing import Optional
 
 from astropy.time import TimeDelta
 import astropy.units as u
@@ -36,7 +37,7 @@ def parse_configuration(enum_class: Type[Enum], value: str) -> Any:
 
 
 class Blueprint:
-    """Base class for Blueprint
+    """Base class for a Blueprint.
     """
     pass
 
@@ -64,8 +65,24 @@ class CollectorBlueprint(Blueprint):
                      self.obs_classes))
 
 
-class OptimizerBlueprint(Blueprint):
+class SelectorBlueprint(Blueprint):
     """Blueprint for the Selector.
+    This is based on the configuration in config.yml used to specify the buffer time to determine by how much programs
+    may go over their time limit.
+    """
+    def __init__(self,
+                 buffer_type_str: str,
+                 buffer_amount: Optional[float]):
+        self.buffer_type_str = buffer_type_str
+        self.buffer_amount = buffer_amount
+
+    def __iter__(self):
+        return iter((self.buffer_type_str,
+                     self.buffer_amount))
+
+
+class OptimizerBlueprint(Blueprint):
+    """Blueprint for the Optimizer.
     This is based on the configuration in config.yml.
     """
 
@@ -81,11 +98,13 @@ class OptimizerBlueprint(Blueprint):
             raise ConfigurationError('Optimizer', config.optimizer.name)
 
     def __iter__(self):
-        return iter([self.algorithm])
+        return iter((self.algorithm,))
 
 
 class Blueprints:
     collector: CollectorBlueprint = CollectorBlueprint(config.collector.observation_classes,
                                                        config.collector.program_types,
                                                        config.collector.time_slot_length)
+    selector: SelectorBlueprint = SelectorBlueprint(config.selector.buffer_type,
+                                                    config.selector.buffer_amount)
     optimizer: OptimizerBlueprint = OptimizerBlueprint(config.optimizer.name)

--- a/scheduler/core/builder/blueprint.py
+++ b/scheduler/core/builder/blueprint.py
@@ -11,8 +11,7 @@ from lucupy.minimodel.observation import ObservationClass
 from lucupy.minimodel.program import ProgramTypes
 
 from scheduler.config import config, ConfigurationError
-from scheduler.core.components.optimizer.dummy import DummyOptimizer
-from scheduler.core.components.optimizer.greedymax import GreedyMaxOptimizer
+from scheduler.core.components.optimizer.optimizers import BaseOptimizer, Optimizers
 
 
 def parse_configuration(enum_class: Type[Enum], value: str) -> Any:
@@ -74,14 +73,11 @@ class OptimizerBlueprint(Blueprint):
         self.algorithm = OptimizerBlueprint._parse_optimizer(algorithm)
 
     @staticmethod
-    def _parse_optimizer(algorithm_name: str):
-        # TODO: Enums are needed but for now is just Dummy
-        # TODO: When GMax is ready we can expand
-        if algorithm_name.upper() == 'DUMMY':
-            return DummyOptimizer()
-        elif algorithm_name.upper() == 'GREEDYMAX':
-            return GreedyMaxOptimizer()
-        else:
+    def _parse_optimizer(algorithm_name: str) -> BaseOptimizer:
+        try:
+            instantiator = Optimizers[algorithm_name.upper()]
+            return instantiator.value()
+        except KeyError:
             raise ConfigurationError('Optimizer', config.optimizer.name)
 
     def __iter__(self):

--- a/scheduler/core/builder/schedulerbuilder.py
+++ b/scheduler/core/builder/schedulerbuilder.py
@@ -7,9 +7,10 @@ from astropy.time import Time
 from lucupy.minimodel import CloudCover, ImageQuality, Semester, Site
 from typing import Dict, FrozenSet, Optional
 
-from .blueprint import CollectorBlueprint, OptimizerBlueprint
+from .blueprint import CollectorBlueprint, SelectorBlueprint, OptimizerBlueprint
 from scheduler.core.components.collector import Collector
 from scheduler.core.components.selector import Selector
+from scheduler.core.components.selector.timebuffer import create_time_buffer
 from scheduler.core.components.optimizer import Optimizer
 from scheduler.core.sources import Sources
 from scheduler.core.eventsqueue import EventQueue
@@ -40,10 +41,12 @@ class SchedulerBuilder(ABC):
     @staticmethod
     def build_selector(collector: Collector,
                        num_nights_to_schedule: int,
+                       blueprint: SelectorBlueprint,
                        cc_per_site: Optional[Dict[Site, CloudCover]] = None,
-                       iq_per_site: Optional[Dict[Site, ImageQuality]] = None):
+                       iq_per_site: Optional[Dict[Site, ImageQuality]] = None) -> Selector:
         return Selector(collector=collector,
                         num_nights_to_schedule=num_nights_to_schedule,
+                        time_buffer=create_time_buffer(*blueprint),
                         cc_per_site=cc_per_site or {},
                         iq_per_site=iq_per_site or {})
 

--- a/scheduler/core/components/optimizer/greedymax.py
+++ b/scheduler/core/components/optimizer/greedymax.py
@@ -748,6 +748,8 @@ class GreedyMaxOptimizer(BaseOptimizer):
 
         # print("Running score_program")
         program_calculations = self.selection.score_program(program)
+        if program_calculations is None:
+            return None
 
         # print("Re-score incomplete schedulable_groups")
         for unique_group_id in program_calculations.top_level_groups:

--- a/scheduler/core/components/optimizer/optimizers.py
+++ b/scheduler/core/components/optimizer/optimizers.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2016-2024 Association of Universities for Research in Astronomy, Inc. (AURA)
+# For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+from enum import Enum
+
+from .base import BaseOptimizer
+from .dummy import DummyOptimizer
+from .greedymax import GreedyMaxOptimizer
+
+from lucupy.types import Instantiable
+
+
+class Optimizers(Instantiable[BaseOptimizer], Enum):
+    DUMMY = Instantiable(lambda: DummyOptimizer())
+    GREEDYMAX = Instantiable(lambda: GreedyMaxOptimizer())

--- a/scheduler/core/components/selector/__init__.py
+++ b/scheduler/core/components/selector/__init__.py
@@ -204,6 +204,11 @@ class Selector(SchedulerComponent):
         If the sites used by the Program do not intersect the sites parameter, then None is returned.
         Otherwise, the data is bundled in a ProgramCalculations object.
         """
+        # Check if there is any time left for the program, allowing for the time buffer. If not, skip it.
+        if program.program_awarded() + self.time_buffer(program) <= program.program_used():
+            logger.info(f'Program {program.id.id} out of time: skipping.')
+            return None
+
         # The night_indices in the Selector must be a subset of the Ranker.
         night_indices_set = set(night_indices)
         if not night_indices_set.issubset(ranker.night_indices):

--- a/scheduler/core/components/selector/__init__.py
+++ b/scheduler/core/components/selector/__init__.py
@@ -20,6 +20,7 @@ from scheduler.core.calculations import GroupData, GroupDataMap, GroupInfo, Prog
 from scheduler.core.components.base import SchedulerComponent
 from scheduler.core.components.collector import Collector
 from scheduler.core.components.ranker import DefaultRanker, Ranker
+from scheduler.core.components.selector.timebuffer import TimeBuffer
 from scheduler.core.types import StartingTimeslots
 from scheduler.services import logger_factory
 from scheduler.services.resource import NightConfiguration
@@ -44,6 +45,7 @@ class Selector(SchedulerComponent):
     """
     collector: Collector
     num_nights_to_schedule: int
+    time_buffer: TimeBuffer
     cc_per_site: Dict[Site, CloudCover] = field(default_factory=lambda: {})
     iq_per_site: Dict[Site, ImageQuality] = field(default_factory=lambda: {})
 

--- a/scheduler/core/components/selector/timebuffer.py
+++ b/scheduler/core/components/selector/timebuffer.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2016-2024 Association of Universities for Research in Astronomy, Inc. (AURA)
+# For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+from abc import abstractmethod, ABC
+from dataclasses import dataclass
+from datetime import timedelta
+from enum import auto, Enum
+from typing import final, Optional
+
+from lucupy.minimodel import Program
+from lucupy.types import ZeroTime
+
+from scheduler.config import ConfigurationError
+
+
+__all__ = [
+    'TimeBuffer',
+    'create_time_buffer',
+]
+
+
+class TimeBufferType(Enum):
+    NONE = auto()
+    FLAT_MINUTES = auto()
+    PERCENTAGE = auto()
+
+
+class TimeBuffer(ABC):
+    def __call__(self, *args, **kwargs):
+        if len(args) != 1 or kwargs:
+            raise ValueError("TimeBuffer expects exactly one positional argument (Program) with no keyword arguments.")
+        p, = args
+
+        if not isinstance(p, Program):
+            raise TypeError("TimeBuffer argument must be an instance of Program.")
+
+        return self._calculate_time(p)
+
+    @abstractmethod
+    def _calculate_time(self, program: Program) -> timedelta:
+        ...
+
+
+@final
+@dataclass(frozen=True)
+class NoTimeBuffer(TimeBuffer):
+    def _calculate_time(self, program: Program) -> timedelta:
+        return ZeroTime
+
+
+@final
+@dataclass(frozen=True)
+class PercentageTimeBuffer(TimeBuffer):
+    percentage: float
+
+    def _calculate_time(self, p: Program) -> timedelta:
+        return p.program_awarded() * (1.0 + self.percentage)
+
+
+@final
+@dataclass(frozen=True)
+class FlatTimeBuffer(TimeBuffer):
+    time_amount: timedelta
+
+    def _calculate_time(self, _: Program) -> timedelta:
+        return self.time_amount
+
+
+def create_time_buffer(buffer_type_str: str,
+                       buffer_amount: Optional[float]) -> TimeBuffer:
+    """
+    Create a TimeBuffer based on the configuration parameters in config.yaml.
+
+    Note that all validation is done in here to keep it centralized, and ConfigurationErrors are raised
+    if there are incompatible values.
+    """
+    try:
+        time_buffer_type = TimeBufferType[buffer_type_str.upper()]
+    except KeyError:
+        raise ConfigurationError('buffer_type', buffer_type_str)
+
+    match time_buffer_type:
+        case TimeBufferType.NONE:
+            return NoTimeBuffer()
+
+        case TimeBufferType.PERCENTAGE:
+            if buffer_amount is None or not (0 < buffer_amount < 1):
+                raise ConfigurationError('buffer_amount', str(buffer_amount))
+            return PercentageTimeBuffer(buffer_amount)
+
+        case TimeBufferType.FLAT_MINUTES:
+            if buffer_amount is None or buffer_amount <= 0:
+                raise ConfigurationError('buffer_amount', str(buffer_amount))
+            return FlatTimeBuffer(time_amount=timedelta(minutes=buffer_amount))
+
+        case _:
+            # This only happens if we add something to TimeBufferType and do not implement it here.
+            raise ConfigurationError('buffer_type', buffer_type_str)

--- a/scheduler/core/service/service.py
+++ b/scheduler/core/service/service.py
@@ -237,11 +237,13 @@ class Service:
 
         selector = builder.build_selector(collector,
                                           num_nights_to_schedule,
-                                          cc_per_site=cc_per_site,
-                                          iq_per_site=iq_per_site
-                                          )
+                                          Blueprints.selector,
+                                          cc_per_site,
+                                          iq_per_site)
+
         # Create the ChangeMonitor and keep track of when we should recalculate the plan for each site.
         change_monitor = ChangeMonitor(collector=collector, selector=selector)
+
         # Don't use this now, but we will use it when scheduling sites at the same time.
         next_update: Dict[Site, Optional[TimeCoordinateRecord]] = {site: None for site in sites}
 

--- a/scheduler/core/sources.py
+++ b/scheduler/core/sources.py
@@ -6,13 +6,14 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from enum import Enum
 from io import BytesIO
-from typing import Optional, NoReturn, FrozenSet
+from typing import Callable, FrozenSet, NoReturn, Optional
 
 from scheduler.services.abstract import ExternalService
 from scheduler.services.environment import OcsEnvService
 from scheduler.services.resource import FileResourceService, OcsResourceService
 
 from lucupy.minimodel import Site
+from lucupy.types import Instantiable
 
 
 # TODO: This file will need significant cleanup after the initial demo version is released.
@@ -58,15 +59,7 @@ class FileOrigin(Origin):
         return self
 
 
-class Instantiable:
-    def __init__(self, func):
-        self.func = func
-
-    def __call__(self):
-        return self.func()
-
-
-class Origins(Enum):
+class Origins(Instantiable[Origin], Enum):
     FILE = Instantiable(lambda: FileOrigin())
     OCS = Instantiable(lambda: OCSOrigin())
     GPP = Instantiable(lambda: GPPOrigin())

--- a/scheduler/scripts/run_main.py
+++ b/scheduler/scripts/run_main.py
@@ -8,12 +8,12 @@ import numpy as np
 from astropy.time import Time
 from lucupy.minimodel import NightIndex, TimeslotIndex
 from lucupy.minimodel.constraints import CloudCover, ImageQuality, VariantChange
-from lucupy.minimodel.semester import Semester, SemesterHalf
+from lucupy.minimodel.semester import Semester
 from lucupy.minimodel.site import ALL_SITES, Site
 from lucupy.observatory.abstract import ObservatoryProperties
 from lucupy.observatory.gemini import GeminiProperties
 
-from scheduler.core.builder.blueprint import CollectorBlueprint, OptimizerBlueprint
+from scheduler.core.builder.blueprint import CollectorBlueprint, SelectorBlueprint, OptimizerBlueprint
 from scheduler.core.builder.validationbuilder import ValidationBuilder
 from scheduler.core.components.ranker import RankerParameters, DefaultRanker
 from scheduler.core.components.changemonitor import ChangeMonitor, TimeCoordinateRecord
@@ -81,8 +81,13 @@ def main(*,
         print_collector_info(collector)
 
     # Create the Selector.
+    selector_blueprint = SelectorBlueprint(
+        'FLAT_MINUTES',
+        30
+    )
     selector = builder.build_selector(collector,
                                       num_nights_to_schedule=num_nights_to_schedule,
+                                      blueprint=selector_blueprint,
                                       cc_per_site=cc_per_site,
                                       iq_per_site=iq_per_site)
 


### PR DESCRIPTION
This PR focuses on several things:
1. Configuration of a `TimeBuffer` to allow programs to surpass their allocated time (by either a flat number of minutes or a percentage of the program length) in the `config.yaml` file. By default, this is configured to be 30 minutes.
3. The `Selector` now has a `SelectorBlueprint` and is created by the `Builder`.
4. The `Selector` now stores the `TimeBuffer` to use in scoring.
5. If a program is out of time (with the inclusion of the added buffer time calculated for the program via the `TimeBuffer`), we terminate its `ProgramCalculations` and return `None`.
6. GreedyMax is modified to handle `ProgramCalculations` being `None` during program re-scoring.

It requires an update to lucupy to run correctly or it will break.

It also:
1. Moves `Instantiable` to lucupy.
2. Changes the algorithm instantiation code to use an `Enum` with `Instantiable`.
(This was done because I thought I was going to use `Instantiable` for the `TimeBuffer`, but that ended up not quite working.)