### PR TITLE
Import of classical programs, fix parsing of visitor instrument names

### DIFF
--- a/scheduler/core/builder/validationbuilder.py
+++ b/scheduler/core/builder/validationbuilder.py
@@ -84,7 +84,7 @@ class ValidationBuilder(SchedulerBuilder):
                         program_list: Optional[bytes] = None) -> Collector:
 
         collector = super().build_collector(start, end, sites, semesters, blueprint)
-        collector.load_programs(program_provider_class=OcsProgramProvider, data=ocs_program_data())
+        collector.load_programs(program_provider_class=OcsProgramProvider, data=ocs_program_data(program_list))
         ValidationBuilder.reset_collector_observations(collector)
         return collector
 

--- a/scheduler/core/programprovider/ocs/__init__.py
+++ b/scheduler/core/programprovider/ocs/__init__.py
@@ -39,10 +39,11 @@ def ocs_program_data(program_list: Optional[bytes] = None) -> Iterable[dict]:
     try:
         # Try to read the file and create a frozenset from its lines
         if program_list:
-            id_frozenset = frozenset(line.strip() for line in program_list.decode("utf-8") if line.strip())
+            list_file = program_list
         else:
-            with DEFAULT_PROGRAM_ID_PATH.open('r') as file:
-                id_frozenset = frozenset(line.strip() for line in file if line.strip())
+            list_file = DEFAULT_PROGRAM_ID_PATH
+        with list_file.open('r') as file:
+            id_frozenset = frozenset(line.strip() for line in file if line.strip())
     except FileNotFoundError:
         # If the file does not exist, set id_frozenset to None
         id_frozenset = None

--- a/scheduler/scripts/run_greedymax.py
+++ b/scheduler/scripts/run_greedymax.py
@@ -7,4 +7,5 @@ from scheduler.core.components.ranker import RankerParameters
 if __name__ == '__main__':
     main(test_events=True,
          ranker_parameters=RankerParameters(),
+         programs_ids = None,
          verbose=False)

--- a/scheduler/scripts/run_main.py
+++ b/scheduler/scripts/run_main.py
@@ -46,7 +46,7 @@ def main(*,
     # Create the Collector and load the programs.
     collector_blueprint = CollectorBlueprint(
         ['SCIENCE', 'PROGCAL', 'PARTNERCAL'],
-        ['Q', 'LP', 'FT', 'DD'],
+        ['Q', 'LP', 'FT', 'DD', 'C'],
         1.0
     )
 
@@ -75,7 +75,7 @@ def main(*,
         programs_path = Path(programs_ids)
 
         if programs_path.exists():
-            f_programs = open(programs_path, "r+")
+            f_programs = programs_path
         else:
             raise ValueError(f'Path {programs_path} does not exist.')
 

--- a/scheduler/services/resource/file_based_resource_service.py
+++ b/scheduler/services/resource/file_based_resource_service.py
@@ -318,9 +318,9 @@ class FileBasedResourceService(ResourceService):
                 if filename != 'GCAL' and filename not in instrument_column_mapping:
                     raise KeyError(f'{msg} contains instrument name with no column: {filename}.')
                 try:
-                    # TODO: Temporary: GCAL does not have its own column. Unsure of how to handle this.
+                    # GCAL does not have its own column, treat as always available
                     if filename == 'GCAL':
-                        instrument_status = ''
+                        instrument_status = FileBasedResourceService._SCIENCE
                     else:
                         instrument_status = none_to_str(row[instrument_column_mapping[filename]].value).strip().upper()
                 except IndexError:


### PR DESCRIPTION
Allow import of classical programs into the collector by making them equivalent to Band 1.
Fix parsing of visitor instrument names to match the resources in the telescope calendar
Make GCAL an always available resource, which is the case. This removes a lot of warning messages but doesn't affect scheduling at this time.