### PR TITLE
SCHED-621: Adding GCAL to resources to fix test cases.

### DIFF
--- a/tests/unit/scheduler/services/resource/test_ocs_resource_service.py
+++ b/tests/unit/scheduler/services/resource/test_ocs_resource_service.py
@@ -20,6 +20,7 @@ def year():
 def test_specific_date_gn():
     expected = sorted([
         Site.GN.resource,
+        Resource(id='GCAL'),
         Resource(id='Altair'),
         Resource(id='NIRI'),
         Resource(id='GMOS OIWFS'),
@@ -60,6 +61,7 @@ def test_specific_date_gn():
 def test_specific_date_gs():
     expected = sorted([
         Site.GS.resource,
+        Resource(id='GCAL'),
         Resource(id='B600'),
         Resource(id='R150'),
         Resource(id='R400'),


### PR DESCRIPTION
This PR broke the test cases by adding `GCAL` to the list of resources, so here we fix it by adding `GCAL` to the expected resources.