### PR TITLE
GSCHED-616: program priorities based on telescope calendar

### DIFF
--- a/scheduler/scripts/filter_demo.py
+++ b/scheduler/scripts/filter_demo.py
@@ -2,16 +2,22 @@
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 import logging
+from astropy.time import Time
 
 from lucupy.observatory.abstract import ObservatoryProperties
 from lucupy.observatory.gemini import GeminiProperties
 from lucupy.minimodel import SemesterHalf
+from lucupy.minimodel.site import ALL_SITES, Site
+from lucupy.minimodel import NightIndex, TimeslotIndex
+from lucupy.minimodel.semester import Semester
+from lucupy.minimodel import ProgramID
 
 from scheduler.core.builder.blueprint import CollectorBlueprint
-from scheduler.core.builder.builder import ValidationBuilder
+from scheduler.core.builder.validationbuilder import ValidationBuilder
 from scheduler.core.components.collector import *
 from scheduler.core.eventsqueue import EventQueue
 from scheduler.core.output import print_collector_info
+from scheduler.core.sources import Sources
 from scheduler.services import logger_factory
 from scheduler.services.resource import (CompositeFilter, OcsResourceService, ProgramPriorityFilter,
                                          ProgramPermissionFilter, ResourcesAvailableFilter)
@@ -66,6 +72,7 @@ if __name__ == '__main__':
     f_program_filtering = ProgramPermissionFilter(
         program_ids=program_ids
     )
+
     print(f'\n\nPROGRAM FILTERING ON {program_ids}:')
     for pid, program in program_data.items():
         if f_program_filtering.program_filter(program):
@@ -84,6 +91,7 @@ if __name__ == '__main__':
             print(f'--- Program {pid} is rejected.')
 
     resources = frozenset({
+            resource_service.lookup_resource('Gemini South'),
             resource_service.lookup_resource('GMOS-S'),
             resource_service.lookup_resource('Mirror'),
             resource_service.lookup_resource('B600'),

--- a/scheduler/scripts/run_greedymax.py
+++ b/scheduler/scripts/run_greedymax.py
@@ -7,5 +7,5 @@ from scheduler.core.components.ranker import RankerParameters
 if __name__ == '__main__':
     main(test_events=True,
          ranker_parameters=RankerParameters(),
-         programs_ids = None,
+         programs_ids=None,
          verbose=False)

--- a/scheduler/services/resource/filters.py
+++ b/scheduler/services/resource/filters.py
@@ -49,6 +49,13 @@ class AbstractFilter(ABC):
         return None
 
     @property
+    def program_priority_filter_any(self) -> Optional[ProgramFilter]:
+        """
+        Determine if a program is in the Priority Filter positive list
+        """
+        return None
+
+    @property
     def group_filter(self) -> Optional[GroupFilter]:
         """
         Determine the groups that can be added to the plan.
@@ -168,6 +175,10 @@ class NothingFilter(AbstractFilter):
         return lambda _: False
 
     @property
+    def program_priority_filter_any(self) -> Optional[ProgramFilter]:
+        return lambda _: False
+
+    @property
     def group_filter(self) -> Optional[GroupFilter]:
         return lambda _: False
 
@@ -226,6 +237,13 @@ class CompositeFilter(AbstractFilter):
     @property
     def program_priority_filter(self) -> Optional[ProgramFilter]:
         return (lambda p: all(pf.program_priority_filter(p) for pf in self.positive_filters
+                              if pf.program_priority_filter is not None) and
+                not any(nf.program_priority_filter(p) for nf in self.negative_filters
+                        if nf.program_priority_filter is not None))
+
+    @property
+    def program_priority_filter_any(self) -> Optional[ProgramFilter]:
+        return (lambda p: any(pf.program_priority_filter(p) for pf in self.positive_filters
                               if pf.program_priority_filter is not None) and
                 not any(nf.program_priority_filter(p) for nf in self.negative_filters
                         if nf.program_priority_filter is not None))


### PR DESCRIPTION
Two ways of using the telescope calendar to adjust program score are implemented
- observation visibilities for a night are only included in the visfrac calculations if the program is allowed to be scheduled on the night (program_filter) 
- an extra program_priority term has been added to the ranker to allow programs with program_priority status to be given a scoring boost.