### PR TITLE
Fix parsing GRACES sequences and calendar availability

### DIFF
--- a/scheduler/core/components/optimizer/greedymax.py
+++ b/scheduler/core/components/optimizer/greedymax.py
@@ -187,8 +187,10 @@ class GreedyMaxOptimizer(BaseOptimizer):
                         sci_times_min.append(time_remain)
 
                     # NIR science time for to determine the number of tellurics
-                    if any(inst in group.required_resources() for inst in NIR_INSTRUMENTS):
+                    if any(inst in obs.required_resources() for inst in NIR_INSTRUMENTS):
                         exec_sci_nir += time_remain
+                        if verbose:
+                            print(f'Adding {time_remain} to exec_sci_nir')
                 elif obs.obs_class == ObservationClass.PARTNERCAL:
                     # Partner calibration time, no splitting of partner cals
                     nprt += 1
@@ -458,9 +460,6 @@ class GreedyMaxOptimizer(BaseOptimizer):
         """
         Return the starting and ending timeline slots (indices) for the NIR science observations.
         """
-        # TODO: This should probably be moved to a more general location
-        nir_inst = [Resource('Flamingos2'), Resource('GNIRS'), Resource('NIRI'), Resource('NIFS'),
-                    Resource('IGRINS')]
 
         # science, split at atom
         slot_start_nir = None
@@ -483,7 +482,7 @@ class GreedyMaxOptimizer(BaseOptimizer):
 
             slot_end = slot_start + visit_length - 1
             # NIR science time for to determine the number of tellurics
-            if any(inst in obs.required_resources() for inst in nir_inst):
+            if any(inst in obs.required_resources() for inst in NIR_INSTRUMENTS):
                 if slot_start_nir is None:
                     slot_start_nir = slot_start + n_slots_acq  # start of the science sequence, after acq
                 slot_end_nir = slot_end
@@ -914,6 +913,15 @@ class GreedyMaxOptimizer(BaseOptimizer):
             prog_obs = max_group_info.group_data.group.program_observations()
             part_obs = max_group_info.group_data.group.partner_observations()
 
+            # print(f'Adding {max_group_info.group_data.group.unique_id.id} MaxScore:{max_group_info.max_score:7.2f} '
+            #       f'n_std:{max_group_info.n_std} obs_mode:{max_group_info.group_data.group.obs_mode()} '
+            #       f'nir_sci:{max_group_info.exec_sci_nir}')
+            # print(f'{max_group_info.group_data.group.required_resources()}')
+            # [print(wav) for wav in max_group_info.group_data.group.wavelengths()]
+            # print('Program observations')
+            # [print(f'\t {obs.unique_id.id}') for obs in prog_obs]
+            # print('Partner observations')
+            # [print(f'\t {obs.unique_id.id}') for obs in part_obs]
             if max_group_info.n_std > 0:
                 if max_group_info.exec_sci_nir > ZeroTime:
                     standards, place_before = self.place_standards(night_idx, best_interval, prog_obs, part_obs,

--- a/scheduler/core/components/optimizer/greedymax.py
+++ b/scheduler/core/components/optimizer/greedymax.py
@@ -998,4 +998,4 @@ class GreedyMaxOptimizer(BaseOptimizer):
                                              obs_in_plan.visit_score,
                                              obs_in_plan.peak_score)
                     plans[timeline.site].update_time_slots(timeline.slots_unscheduled())
-            print('')
+            # print('')

--- a/scheduler/services/resource/file_based_resource_service.py
+++ b/scheduler/services/resource/file_based_resource_service.py
@@ -330,6 +330,11 @@ class FileBasedResourceService(ResourceService):
                     instrument_status = ''
                 if instrument_status == FileBasedResourceService._SCIENCE:
                     resources.add(self.lookup_resource(filename, resource_type=ResourceType.INSTRUMENT))
+                    # Check for GRACES if GMOS-N is available
+                    if filename == 'GMOS-N':
+                        graces_status = none_to_str(row[instrument_column_mapping['GRACES']].value).strip().upper()
+                        if graces_status == FileBasedResourceService._SCIENCE:
+                            resources.add(self.lookup_resource('GRACES', resource_type=ResourceType.INSTRUMENT))
                 elif not instrument_status:
                     logger.warning(f'{msg} contains no instrument status for {filename}. '
                                    'Using default of Not Available.')


### PR DESCRIPTION
GRACES sequences are non-standard so the acquisition steps have to be ignored.
Since GRACES is accessed via GMOS-N it does not appear in a Port column in the telescope calendar. We check the GRACES availability if GMOS-N is also available. (Note, use of the port columns and the instrument columns is redundant. In the future we could simplify this by just using the instrument columns for availability and adding the port as part of the configuration in case it is needed, eg. for AGS. This is low priority).