### PR TITLE
SCHED 633: Add weather change events 

### DIFF
--- a/scheduler/core/components/changemonitor/change_monitor.py
+++ b/scheduler/core/components/changemonitor/change_monitor.py
@@ -111,7 +111,7 @@ class ChangeMonitor(SchedulerComponent):
                 plan = plans[site]
                 sorted_visits = sorted(plan.visits, key=lambda v: v.start_time_slot)
                 visit_idx = bisect.bisect_right([v.start_time_slot for v in sorted_visits], event_timeslot)-1
-                print(visit_idx, len(sorted_visits))
+
                 visit = None if visit_idx < 0 else sorted_visits[visit_idx]
 
                 # There are no visits currently in progress, so immediately calculate new plan and do TA.
@@ -120,8 +120,8 @@ class ChangeMonitor(SchedulerComponent):
                                                 timeslot_idx=event_timeslot)
 
                 # Otherwise, we are in the middle of a visit.
-                end_time_slot = visit.start_time_slot + visit.time_slots
-                remaining_time_slots = end_time_slot - event_timeslot + 1
+                end_time_slot = visit.start_time_slot + visit.time_slots - 1
+                remaining_time_slots = end_time_slot - event_timeslot
 
                 # TODO: This should be more complicated to allow for splitting and to meet requirements.
                 # TODO: Talk to Bryan about how to go about this.

--- a/scheduler/core/components/changemonitor/change_monitor.py
+++ b/scheduler/core/components/changemonitor/change_monitor.py
@@ -120,8 +120,8 @@ class ChangeMonitor(SchedulerComponent):
                                                 timeslot_idx=event_timeslot)
 
                 # Otherwise, we are in the middle of a visit.
-                end_time_slot = visit.start_time_slot + visit.time_slots - 1
-                remaining_time_slots = end_time_slot - event_timeslot
+                end_time_slot = visit.start_time_slot + visit.time_slots
+                remaining_time_slots = end_time_slot - event_timeslot + 1
 
                 # TODO: This should be more complicated to allow for splitting and to meet requirements.
                 # TODO: Talk to Bryan about how to go about this.
@@ -173,7 +173,6 @@ class ChangeMonitor(SchedulerComponent):
                 actual_conditions = self.collector.sources.origin.env.get_actual_conditions_variant(obs.site,
                                                                                                     start_time,
                                                                                                     end_time)
-
                 # TODO: Hack to make test cases pass.
                 if remaining_time_slots != len(actual_conditions.cc):
                     _logger.error(f'Expected {remaining_time_slots} entries in CC, got {len(actual_conditions.cc)}.')
@@ -185,6 +184,7 @@ class ChangeMonitor(SchedulerComponent):
                 if remaining_time_slots != len(actual_conditions.wind_spd):
                     _logger.error(f'Expected {remaining_time_slots} entries in wind speed, got '
                                   f'{len(actual_conditions.wind_spd)}.')
+                input()
                 remaining_time_slots = max(remaining_time_slots, len(actual_conditions.cc))
 
                 # Since a Variant is a frozen dataclass, swap the new values in.

--- a/scheduler/core/components/changemonitor/change_monitor.py
+++ b/scheduler/core/components/changemonitor/change_monitor.py
@@ -110,7 +110,8 @@ class ChangeMonitor(SchedulerComponent):
                 # Check if there is a visit running now.
                 plan = plans[site]
                 sorted_visits = sorted(plan.visits, key=lambda v: v.start_time_slot)
-                visit_idx = bisect.bisect_right([v.start_time_slot for v in sorted_visits], event_timeslot)
+                visit_idx = bisect.bisect_right([v.start_time_slot for v in sorted_visits], event_timeslot)-1
+                print(visit_idx, len(sorted_visits))
                 visit = None if visit_idx < 0 else sorted_visits[visit_idx]
 
                 # There are no visits currently in progress, so immediately calculate new plan and do TA.
@@ -197,11 +198,11 @@ class ChangeMonitor(SchedulerComponent):
                 if variant_change.wind_dir is None:
                     wind_dir = actual_conditions.wind_dir
                 else:
-                    wind_dir = np.array([variant_change.wind_dir] * remaining_time_slots)
+                    wind_dir = np.array([variant_change.wind_dir.degree] * remaining_time_slots)
                 if variant_change.wind_spd is None:
                     wind_spd = actual_conditions.wind_spd
                 else:
-                    wind_spd = np.array([variant_change.wind_spd] * remaining_time_slots)
+                    wind_spd = np.array([variant_change.wind_spd.value] * remaining_time_slots)
                 actual_conditions = Variant(cc=np.array([variant_change.cc] * remaining_time_slots),
                                             iq=np.array([variant_change.iq] * remaining_time_slots),
                                             wind_spd=wind_spd,

--- a/scheduler/core/service/service.py
+++ b/scheduler/core/service/service.py
@@ -46,8 +46,6 @@ class Service:
 
     @staticmethod
     def _schedule_nights(night_indices: FrozenSet[NightIndex],
-                         start_vis: Time,
-                         end_vis: Time,
                          sites: FrozenSet[Site],
                          collector: Collector,
                          selector: Selector,
@@ -75,14 +73,13 @@ class Service:
                 morn_twi = MorningTwilightEvent(site=site, time=morn_twi_time, description='Morning 12° Twilight')
                 queue.add_event(night_idx, site, morn_twi)
 
-                # Add weather changes to queue
-                delta = TimeDelta(1, format='jd')
-
-                night_variants = collector.sources.origin.env.get_night_weather_changes(site, Time(eve_twi_time), Time(morn_twi_time))
+                night_variants = collector.sources.origin.env.get_night_weather_changes(site,
+                                                                                        Time(eve_twi_time),
+                                                                                        Time(morn_twi_time))
                 for dt, variant in night_variants.items():
 
                     weather_change = WeatherChangeEvent(time=dt.replace(tzinfo=site.timezone),
-                                                        description=f'New conditions:',
+                                                        description=f'New conditions: IQ: {variant.iq}, CC: {variant.cc}',
                                                         variant_change=variant)
                     queue.add_event(NightIndex(night_idx), site, weather_change)
 
@@ -150,7 +147,7 @@ class Service:
                             _logger.info(
                                 f'Received event for site {site_name} for night idx {night_idx} to be processed '
                                 f'at timeslot {next_event_timeslot}: {next_event.__class__.__name__}')
-
+                            print(next_event)
                             # Process the event: find out when it should occur.
                             # If there is no next update planned, then take it to be the next update.
                             # If there is a next update planned, then take it if it happens before the next update.
@@ -291,8 +288,6 @@ class Service:
         optimizer = builder.build_optimizer(Blueprints.optimizer)
 
         timelines = self._schedule_nights(night_indices,
-                                          start_vis,
-                                          end_vis,
                                           sites,
                                           collector,
                                           selector,

--- a/scheduler/core/service/service.py
+++ b/scheduler/core/service/service.py
@@ -78,7 +78,8 @@ class Service:
                                                                                         Time(morn_twi_time))
                 for dt, variant in night_variants.items():
 
-                    weather_change = WeatherChangeEvent(time=dt.replace(tzinfo=site.timezone),
+                    weather_change = WeatherChangeEvent(site=site,
+                                                        time=dt.replace(tzinfo=site.timezone),
                                                         description=f'New conditions: IQ: {variant.iq}, CC: {variant.cc}',
                                                         variant_change=variant)
                     queue.add_event(NightIndex(night_idx), site, weather_change)

--- a/scheduler/scripts/run_greedymax.py
+++ b/scheduler/scripts/run_greedymax.py
@@ -5,7 +5,7 @@ from run_main import main
 from scheduler.core.components.ranker import RankerParameters
 
 if __name__ == '__main__':
-    main(test_events=True,
+    main(test_events=False,
          ranker_parameters=RankerParameters(),
          programs_ids=None,
          verbose=False)

--- a/scheduler/scripts/run_main.py
+++ b/scheduler/scripts/run_main.py
@@ -295,6 +295,7 @@ def main(*,
                         collector.time_accounting(plans,
                                                   sites=frozenset({site}),
                                                   end_timeslot_bounds=end_timeslot_bounds)
+
                         if update.done:
                             # In the case of the morning twilight, which is the only thing that will
                             # be represented here by update.done, we add no plans (None) since the plans
@@ -304,8 +305,7 @@ def main(*,
                                                  site,
                                                  current_timeslot,
                                                  update.event,
-                                                 plans[site])
-
+                                                 None)
 
                     # Get a new selection and request a new plan if the night is not done.
                     if not update.done:

--- a/scheduler/services/environment/ocs_env_service.py
+++ b/scheduler/services/environment/ocs_env_service.py
@@ -108,9 +108,9 @@ class OcsEnvService(ExternalService):
         )
 
     def get_night_weather_changes(self,
-                                   site: Site,
-                                   start_time: Time,
-                                   end_time: Time) -> Dict[datetime, Variant]:
+                                  site: Site,
+                                  start_time: Time,
+                                  end_time: Time) -> Dict[datetime, Variant]:
 
         def _get_changes(array):
             changes = np.diff(array) != 0
@@ -124,8 +124,8 @@ class OcsEnvService(ExternalService):
         change_iq_idx, change_iq_val = _get_changes(variant.iq)
 
         for cc_i, cc_v, iq_i, iq_v in zip(change_cc_idx, change_cc_val, change_iq_idx, change_iq_val):
-            variants[start_time.to_datetime()+timedelta(minutes=int(cc_i)+1)] = Variant(iq=np.array([iq_v]),
-                                                                                        cc=np.array([cc_v]),
+            variants[start_time.to_datetime()+timedelta(minutes=int(cc_i)+1)] = Variant(iq=iq_v,
+                                                                                        cc=cc_v,
                                                                                         wind_dir=variant.wind_dir[cc_i],
                                                                                         wind_spd=variant.wind_spd[cc_i])
         print(variants)

--- a/scheduler/services/environment/ocs_env_service.py
+++ b/scheduler/services/environment/ocs_env_service.py
@@ -128,5 +128,4 @@ class OcsEnvService(ExternalService):
                                                                                         cc=cc_v,
                                                                                         wind_dir=variant.wind_dir[cc_i],
                                                                                         wind_spd=variant.wind_spd[cc_i])
-        print(variants)
         return variants

--- a/scheduler/services/environment/ocs_env_service.py
+++ b/scheduler/services/environment/ocs_env_service.py
@@ -123,9 +123,18 @@ class OcsEnvService(ExternalService):
         change_cc_idx, change_cc_val = _get_changes(variant.cc)
         change_iq_idx, change_iq_val = _get_changes(variant.iq)
 
-        for cc_i, cc_v, iq_i, iq_v in zip(change_cc_idx, change_cc_val, change_iq_idx, change_iq_val):
-            variants[start_time.to_datetime()+timedelta(minutes=int(cc_i)+1)] = Variant(iq=iq_v,
-                                                                                        cc=cc_v,
-                                                                                        wind_dir=variant.wind_dir[cc_i],
-                                                                                        wind_spd=variant.wind_spd[cc_i])
+        for cc_i, cc_v in zip(change_cc_idx, change_cc_val):
+            variants[start_time.to_datetime() + timedelta(minutes=int(cc_i) + 1)] = Variant(iq=variant.iq[cc_i],
+                                                                                            cc=cc_v,
+                                                                                            wind_dir=variant.wind_dir[
+                                                                                                cc_i],
+                                                                                            wind_spd=variant.wind_spd[
+                                                                                                cc_i])
+        # eliminate duplicates
+        no_duplicates = list(set(change_iq_idx) - set(change_cc_idx))
+        for iq_i in no_duplicates:
+            variants[start_time.to_datetime()+timedelta(minutes=int(iq_i)+1)] = Variant(iq=variant.iq[iq_i],
+                                                                                        cc=variant.cc[iq_i],
+                                                                                        wind_dir=variant.wind_dir[iq_i],
+                                                                                        wind_spd=variant.wind_spd[iq_i])
         return variants


### PR DESCRIPTION
Getting stuck here: 
```
 # TODO: We are getting 1-off errors sometimes by doing the weather lookups this way in the size of
 # TODO: remaining_time_slots.
 start_time = night_events.times[event_night][event_timeslot]
 end_time = night_events.times[event_night][end_time_slot]
 ```
 