### PR TITLE
SCHED-653: Change to VariantSnapshot and simplify code.

### DIFF
--- a/scheduler/core/eventsqueue/events.py
+++ b/scheduler/core/eventsqueue/events.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import final, FrozenSet
 
-from lucupy.minimodel import Resource, Site, TimeslotIndex, VariantChange
+from lucupy.minimodel import Resource, Site, TimeslotIndex, VariantSnapshot
 from lucupy.timeutils import time2slots
 
 
@@ -131,7 +131,7 @@ class WeatherChangeEvent(InterruptionEvent):
     """
     Interruption that occurs when new a new weather variant comes in.
     """
-    variant_change: VariantChange
+    variant_change: VariantSnapshot
 
 
 @final

--- a/scheduler/scripts/run_main.py
+++ b/scheduler/scripts/run_main.py
@@ -7,7 +7,7 @@ from typing import Dict, FrozenSet, Optional
 
 import numpy as np
 from astropy.time import Time
-from lucupy.minimodel import NightIndex, TimeslotIndex, VariantChange
+from lucupy.minimodel import NightIndex, TimeslotIndex, VariantSnapshot
 from lucupy.minimodel.semester import Semester
 from lucupy.minimodel.site import ALL_SITES, Site
 from lucupy.observatory.abstract import ObservatoryProperties
@@ -116,7 +116,7 @@ def main(*,
 
     # Initial weather conditions for a night.
     # These can occur if a weather reading is taken from timeslot 0 or earlier on a night.
-    initial_variants: Dict[Site, Dict[NightIndex, Optional[VariantChange]]] = \
+    initial_variants: Dict[Site, Dict[NightIndex, Optional[VariantSnapshot]]] = \
         {site: {night_idx: None for night_idx in night_indices} for site in sites}
 
     # Add events for every site for each night.
@@ -132,15 +132,17 @@ def main(*,
             night_date = eve_twi_time.date()
             morn_twi_time = night_events.twilight_morning_12[night_idx].to_datetime(site.timezone) - time_slot_length
             morn_twi_slot = time2slots(time_slot_length, morn_twi_time - eve_twi_time)
+
+            # Get the VariantSnapshots for the times of the night where the variant changes.
             variant_changes_dict = collector.sources.origin.env.get_variant_changes_for_night(site, night_date)
-            for variant_datetime, variant_change in variant_changes_dict.items():
+            for variant_datetime, variant_snapshot in variant_changes_dict.items():
                 variant_timeslot = time2slots(time_slot_length, variant_datetime - eve_twi_time)
 
                 # If the variant happens before or at the first time slot, we set the initial variant for the night.
                 # The closer to the first time slot, the more accurate, and the ordering on them will overwrite
                 # the previous values.
                 if variant_timeslot <= 0:
-                    initial_variants[site][night_idx] = variant_change
+                    initial_variants[site][night_idx] = variant_snapshot
                     continue
 
                 if variant_timeslot >= morn_twi_slot:
@@ -150,12 +152,12 @@ def main(*,
 
                 variant_datetime_str = variant_datetime.strftime('%Y-%m-%d %H:%M')
                 weather_change_description = (f'Weather change at {site.name}, {variant_datetime_str}: '
-                                              f'IQ -> {variant_change.iq.name}, '
-                                              f'CC -> {variant_change.cc.name}.')
+                                              f'IQ -> {variant_snapshot.iq.name}, '
+                                              f'CC -> {variant_snapshot.cc.name}.')
                 weather_change_event = WeatherChangeEvent(site=site,
                                                           time=variant_datetime,
                                                           description=weather_change_description,
-                                                          variant_change=variant_change)
+                                                          variant_change=variant_snapshot)
                 queue.add_event(night_idx, site, weather_change_event)
 
             morn_twi = MorningTwilightEvent(site=site, time=morn_twi_time, description='Morning 12° Twilight')
@@ -267,9 +269,9 @@ def main(*,
                     next_update[site] = None
 
                     if current_timeslot > update.timeslot_idx:
-                        _logger.error(
+                        _logger.warning(
                             f'Plan update at {site.name} for night {night_idx} for {update.event.__class__.__name__}'
-                            f' scheduled at timeslot {update.timeslot_idx}, but now timeslot is {current_timeslot}.')
+                            f' scheduled for timeslot {update.timeslot_idx}, but now timeslot is {current_timeslot}.')
 
                     # We will update the plan up until the time that the update happens.
                     # If this update corresponds to the night being done, then use None.

--- a/scheduler/services/environment/ocs_env_service.py
+++ b/scheduler/services/environment/ocs_env_service.py
@@ -9,7 +9,7 @@ from typing import Dict, Final, FrozenSet
 import astropy.units as u
 import pandas as pd
 from astropy.coordinates import Angle
-from lucupy.minimodel import ALL_SITES, CloudCover, ImageQuality, Site, VariantChange
+from lucupy.minimodel import ALL_SITES, CloudCover, ImageQuality, Site, VariantSnapshot
 
 from definitions import ROOT_DIR
 from scheduler.services import logger_factory
@@ -54,7 +54,7 @@ class OcsEnvService(ExternalService):
                 logger.info(f'Weather data for {site.name} read in: {len(self._site_data[site])} rows.')
 
     @staticmethod
-    def _convert_to_variant(row) -> (datetime, VariantChange):
+    def _convert_to_variant(row) -> (datetime, VariantSnapshot):
         """
         Given a pandas row from the weather data, turn it into a Variant object.
         """
@@ -64,15 +64,15 @@ class OcsEnvService(ExternalService):
         wind_dir = Angle(row[OcsEnvService._wind_dir_col], unit=u.deg)
         wind_spd = row[OcsEnvService._wind_speed_col] * (u.m / u.s)
 
-        variant_change = VariantChange(iq=iq,
-                                       cc=cc,
-                                       wind_dir=wind_dir,
-                                       wind_spd=wind_spd)
+        variant_change = VariantSnapshot(iq=iq,
+                                         cc=cc,
+                                         wind_dir=wind_dir,
+                                         wind_spd=wind_spd)
         return timestamp, variant_change
 
     def get_variant_changes_for_night(self,
                                       site: Site,
-                                      night_date: date) -> Dict[datetime, VariantChange]:
+                                      night_date: date) -> Dict[datetime, VariantSnapshot]:
         """
         Return the weather variant.
         This should be site-based and time-based.


### PR DESCRIPTION
To increase the clarity of variable names, `VariantChange` has been renamed to `VariantSnapshot` in lucupy.

Additionally:
1. `VariantSnapshot` can now generate a `Variant` with a specified array (number of timeslots) size.
2. The `Selector` now stores a `VariantSnapshot` per site instead of having arrays for each value.
3. The `Selector` uses `VariantSnapshot.make_variant` to create the `Variant` instead of doing so by hand when scoring an `Observation`.
4. The `ChangeMonitor` uses `VariantSnapshot.make_variant` to create the `Variant` to determine if a `Visit` can be completed when a `WeatherChangeEvent` occurs.
5. The GraphQL code for `NewWeatherChange` was broken inadvertently by changes and has now been repaired.