### PR TITLE
SCHED-630: Add blocking lists for sites to ChangeMonitor.

### DIFF
--- a/scheduler/core/plans/plans.py
+++ b/scheduler/core/plans/plans.py
@@ -22,7 +22,7 @@ class Plans:
     """
     night_events: InitVar[Mapping[Site, NightEvents]]
     night_idx: NightIndex
-    plans: Dict[Site, Plan] = field(init=False, default_factory=lambda: {})
+    plans: Dict[Site, Plan] = field(init=False, default_factory=dict)
 
     def __post_init__(self, night_events: Mapping[Site, NightEvents]):
         self.plans: Dict[Site, Plan] = {}

--- a/scheduler/scripts/run_main.py
+++ b/scheduler/scripts/run_main.py
@@ -306,23 +306,35 @@ def main(*,
                     if not update.done:
                         _logger.debug(f'Calculating selection for {site_name} for night {night_idx} '
                                       f'starting at time slot {current_timeslot}.')
-                        selection = selector.select(night_indices=night_indices,
-                                                    sites=frozenset([site]),
-                                                    starting_time_slots={site: {night_idx: current_timeslot
-                                                                                for night_idx in night_indices}},
-                                                    ranker=ranker)
 
-                        # Right now the optimizer generates List[Plans], a list of plans indexed by
-                        # every night in the selection. We only want the first one, which corresponds
-                        # to the current night index we are looping over.
-                        _logger.debug(f'Running optimizer for {site_name} for night {night_idx} '
-                                      f'starting at time slot {current_timeslot}.')
-                        plans = optimizer.schedule(selection)[0]
-                        nightly_timeline.add(NightIndex(night_idx),
-                                             site,
-                                             current_timeslot,
-                                             update.event,
-                                             plans[site])
+                        # If the site is blocked, we do not perform a selection or optimizer run for the site.
+                        if change_monitor.is_site_unblocked(site):
+                            selection = selector.select(night_indices=night_indices,
+                                                        sites=frozenset([site]),
+                                                        starting_time_slots={site: {night_idx: current_timeslot
+                                                                                    for night_idx in night_indices}},
+                                                        ranker=ranker)
+
+                            # Right now the optimizer generates List[Plans], a list of plans indexed by
+                            # every night in the selection. We only want the first one, which corresponds
+                            # to the current night index we are looping over.
+                            _logger.debug(f'Running optimizer for {site_name} for night {night_idx} '
+                                          f'starting at timeslot {current_timeslot}.')
+                            plans = optimizer.schedule(selection)[0]
+                            nightly_timeline.add(NightIndex(night_idx),
+                                                 site,
+                                                 current_timeslot,
+                                                 update.event,
+                                                 plans[site])
+
+                        else:
+                            # The site is blocked.
+                            _logger.debug(f'Site {site_name} for {night_idx} blocked at timeslot {current_timeslot}.')
+                            nightly_timeline.add(NightIndex(night_idx),
+                                                 site,
+                                                 current_timeslot,
+                                                 update.event,
+                                                 None)
 
                     # Update night_done based on time update record.
                     night_done = update.done


### PR DESCRIPTION
The blocking sites collect and manage events that block a site from creating a plan.
Examples include:
* Weather closure events
* Fault reports
* Other unexpected events (e.g. TMT protests).

Until the blocking events are resolved, the relevant site is unable to be used for scheduling and simply produces empty `Plan`s.