### PR TITLE
SCHED-632: Code to unblock sites if events exist and issue warning if still blocked

### DIFF
--- a/scheduler/core/service/service.py
+++ b/scheduler/core/service/service.py
@@ -109,6 +109,8 @@ class Service:
                 morn_twi = MorningTwilightEvent(site=site, time=morn_twi_time, description='Morning 12° Twilight')
                 queue.add_event(night_idx, site, morn_twi)
 
+                # TODO: If any InterruptionEvents occur before twilight, block the site with the event.
+
         for night_idx in sorted(night_indices):
             night_indices = np.array([night_idx])
             ranker = DefaultRanker(collector, night_indices, sites, params=ranker_parameters)
@@ -271,6 +273,16 @@ class Service:
                     # We have processed all events for this timeslot and performed an update if necessary.
                     # Advance the current time.
                     current_timeslot += 1
+
+                # Process any events still remaining, with the intent of unblocking faults and weather closures.
+                while events_by_night.has_more_events():
+                    event = events_by_night.pop_next_event()
+                    _logger.warning(f'Site {site_name} on night {night_idx} has event after morning twilight: {event}')
+                    change_monitor.process_event(site, event, None, night_idx)
+
+                # The site should no longer be blocked.
+                if not change_monitor.is_site_unblocked(site):
+                    _logger.warning(f'Site {site_name} is still blocked after all events on night {night_idx} processed.')
 
         return nightly_timeline
 


### PR DESCRIPTION
If a site is still blocked by the end of the night:
1. If there are additional events, process them (hoping to unblock the site).
2. If all of the events are processed for a night and the site is still blocked, issue a warning.