### PR TITLE
SCHED-666: Pickling OCS Resource and Env service now works.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,3 @@ plans.lock
 # telescope schedules for the OcsResourceService
 # Edit: include this file now as access to it online requires authorization.
 #scheduler/services/resource/data/telescope_schedules.xlsx
-
-# Pickled services
-/pickles

--- a/.gitignore
+++ b/.gitignore
@@ -120,8 +120,8 @@ maglimits_test.py
 .vscode
 .fleet
 
-# pickle
-*.pickle
+# pickle: We want Heroku to keep the pickles of OCS Env and Resource.
+#*.pickle
 
 # scala worksheet for some OCS comparison
 .metals

--- a/.gitignore
+++ b/.gitignore
@@ -134,5 +134,5 @@ plans.lock
 # Edit: include this file now as access to it online requires authorization.
 #scheduler/services/resource/data/telescope_schedules.xlsx
 
-
-
+# Pickled services
+/pickles

--- a/scheduler/core/builder/validationbuilder.py
+++ b/scheduler/core/builder/validationbuilder.py
@@ -38,7 +38,6 @@ class ValidationBuilder(SchedulerBuilder):
     def __init__(self, sources: Sources, events: EventQueue):
         super().__init__(sources, events)
         self.stats = StatCalculator
-        self.sources.set_origin(Origins.OCS.value())
 
     @staticmethod
     def _clear_observation_info(obs: Iterable[Observation],

--- a/scheduler/core/sources/origins.py
+++ b/scheduler/core/sources/origins.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import final, NoReturn, Optional
-
-from scheduler.services.abstract import ExternalService
-from scheduler.services.environment import OcsEnvService
-from scheduler.services.resource import OcsResourceService
+from pathlib import Path
+from typing import final, Final, NoReturn, Optional
+import pickle
 
 from lucupy.types import Instantiable
+
+from definitions import ROOT_DIR
+from scheduler.services.abstract import ExternalService
+from scheduler.services.logger_factory import create_logger
+from scheduler.services.environment import OcsEnvService
+from scheduler.services.resource import OcsResourceService
 
 
 __all__ = [
@@ -20,6 +24,8 @@ __all__ = [
     'GppOrigin',
     'Origins',
 ]
+
+logger = create_logger(__name__)
 
 
 class Origin(ABC):
@@ -41,12 +47,34 @@ class Origin(ABC):
 
 @final
 class OcsOrigin(Origin):
+    env_path: Final[Path] = Path(ROOT_DIR) / 'scheduler' / 'pickles' / 'ocsenv.pickle'
+    resource_path: Final[Path] = Path(ROOT_DIR) / 'scheduler' / 'pickles' / 'ocsresource.pickle'
+
     def load(self) -> OcsOrigin:
         if not self.is_loaded:
-            self.resource = OcsResourceService()
-            self.env = OcsEnvService()
-            self.is_loaded = True
-            return self
+            try:
+                with open(OcsOrigin.resource_path, 'rb') as res_pickle:
+                    self.resource = pickle.load(res_pickle)
+                    logger.info('Read OCS Resource service from pickle.')
+            except Exception:
+                logger.info('Creating and pickling OCS Resource service.')
+                self.resource = OcsResourceService()
+                OcsOrigin.resource_path.parent.mkdir(parents=True, exist_ok=True)
+                with open(OcsOrigin.resource_path, 'wb') as res_pickle:
+                    pickle.dump(self.resource, res_pickle)
+
+            try:
+                with open(OcsOrigin.env_path, 'rb') as res_env:
+                    self.env = pickle.load(res_env)
+                    logger.info('Read OCS Env service from pickle.')
+            except Exception:
+                logger.info('Creating and pickling OCS Env service.')
+                self.env = OcsEnvService()
+                OcsOrigin.env_path.parent.mkdir(parents=True, exist_ok=True)
+                with open(OcsOrigin.env_path, 'wb') as env_pickle:
+                    pickle.dump(self.env, env_pickle)
+
+        self.is_loaded = True
         return self
 
 

--- a/scheduler/core/sources/origins.py
+++ b/scheduler/core/sources/origins.py
@@ -50,8 +50,12 @@ class OcsOrigin(Origin):
     _env_path: Final[Path] = Path(ROOT_DIR) / 'scheduler' / 'pickles' / 'ocsenv.pickle'
     _resource_path: Final[Path] = Path(ROOT_DIR) / 'scheduler' / 'pickles' / 'ocsresource.pickle'
 
+    def __init__(self):
+        super().__init__()
+        self._is_loaded = False
+
     def load(self) -> OcsOrigin:
-        if not self.is_loaded:
+        if not self._is_loaded:
             try:
                 with open(OcsOrigin._resource_path, 'rb') as res_pickle:
                     self.resource = pickle.load(res_pickle)
@@ -74,7 +78,8 @@ class OcsOrigin(Origin):
                 with open(OcsOrigin._env_path, 'wb') as env_pickle:
                     pickle.dump(self.env, env_pickle)
 
-        self.is_loaded = True
+            self._is_loaded = True
+
         return self
 
 

--- a/scheduler/core/sources/origins.py
+++ b/scheduler/core/sources/origins.py
@@ -47,31 +47,31 @@ class Origin(ABC):
 
 @final
 class OcsOrigin(Origin):
-    env_path: Final[Path] = Path(ROOT_DIR) / 'scheduler' / 'pickles' / 'ocsenv.pickle'
-    resource_path: Final[Path] = Path(ROOT_DIR) / 'scheduler' / 'pickles' / 'ocsresource.pickle'
+    _env_path: Final[Path] = Path(ROOT_DIR) / 'scheduler' / 'pickles' / 'ocsenv.pickle'
+    _resource_path: Final[Path] = Path(ROOT_DIR) / 'scheduler' / 'pickles' / 'ocsresource.pickle'
 
     def load(self) -> OcsOrigin:
         if not self.is_loaded:
             try:
-                with open(OcsOrigin.resource_path, 'rb') as res_pickle:
+                with open(OcsOrigin._resource_path, 'rb') as res_pickle:
                     self.resource = pickle.load(res_pickle)
                     logger.info('Read OCS Resource service from pickle.')
             except Exception:
                 logger.info('Creating and pickling OCS Resource service.')
                 self.resource = OcsResourceService()
-                OcsOrigin.resource_path.parent.mkdir(parents=True, exist_ok=True)
-                with open(OcsOrigin.resource_path, 'wb') as res_pickle:
+                OcsOrigin._resource_path.parent.mkdir(parents=True, exist_ok=True)
+                with open(OcsOrigin._resource_path, 'wb') as res_pickle:
                     pickle.dump(self.resource, res_pickle)
 
             try:
-                with open(OcsOrigin.env_path, 'rb') as res_env:
+                with open(OcsOrigin._env_path, 'rb') as res_env:
                     self.env = pickle.load(res_env)
                     logger.info('Read OCS Env service from pickle.')
             except Exception:
                 logger.info('Creating and pickling OCS Env service.')
                 self.env = OcsEnvService()
-                OcsOrigin.env_path.parent.mkdir(parents=True, exist_ok=True)
-                with open(OcsOrigin.env_path, 'wb') as env_pickle:
+                OcsOrigin._env_path.parent.mkdir(parents=True, exist_ok=True)
+                with open(OcsOrigin._env_path, 'wb') as env_pickle:
                     pickle.dump(self.env, env_pickle)
 
         self.is_loaded = True

--- a/scheduler/core/sources/sources.py
+++ b/scheduler/core/sources/sources.py
@@ -26,7 +26,6 @@ class Sources:
 
     def __init__(self, origin: Origin = Origins.OCS.value()):
         self.origin = None
-        self.set_origin(origin)
 
     def set_origin(self, origin: Origin):
         self.origin = origin.load()

--- a/scheduler/core/sources/sources.py
+++ b/scheduler/core/sources/sources.py
@@ -26,6 +26,7 @@ class Sources:
 
     def __init__(self, origin: Origin = Origins.OCS.value()):
         self.origin = None
+        self.set_origin(origin)
 
     def set_origin(self, origin: Origin):
         self.origin = origin.load()


### PR DESCRIPTION
This code allows the OCS Resource and Env services to be pickled to increase the speed of the executing code.
The bulk of the speed increase is needed in the viscalcs, but this was a good test that `Resource` is now stable and working correctly.

The `Sources` do not load twice now as they did before, and logging is added to display whether the services are loaded from pickles or created.

Plans based on pickled services or freshly created services are the same, as expected.