### PR TITLE
SCHED-683: Remove RA and dec from NonsiderealTarget

### DIFF
--- a/scheduler/core/programprovider/ocs/ocsprogramprovider.py
+++ b/scheduler/core/programprovider/ocs/ocsprogramprovider.py
@@ -508,15 +508,13 @@ class OcsProgramProvider(ProgramProvider):
         des = data.get(OcsProgramProvider._TargetKeys.DES, name)
         tag = data[OcsProgramProvider._TargetKeys.TAG]
 
-        # TODO: ra and dec are last two parameters. Fill here or elsewhere?
+        # RA and dec will be looked up when determining target info in Collector.
         return NonsiderealTarget(
             name=name,
             magnitudes=frozenset(magnitudes),
             type=target_type,
             des=des,
-            tag=tag,
-            ra=np.empty([]),
-            dec=np.empty([]))
+            tag=tag)
 
     @staticmethod
     def _parse_instrument(data: dict) -> str:

--- a/tests/unit/scheduler/core/collector/test_proper_motion.py
+++ b/tests/unit/scheduler/core/collector/test_proper_motion.py
@@ -5,7 +5,7 @@ import pytest
 from astropy.time import Time
 from lucupy.minimodel import SiderealTarget, TargetName, TargetType
 
-from scheduler.core.components.collector import Collector
+from scheduler.services.proper_motion import ProperMotionCalculator
 
 
 @pytest.fixture
@@ -29,6 +29,6 @@ def test_proper_motion(target, time):
     """
     Test that the sun location is at the equator at J2000.
     """
-    coord = Collector._calculate_proper_motion(target, time)
-    assert abs(coord.ra.deg - 78.85740081) < 1e-5
-    assert abs(coord.dec.deg - 15.63008372) < 1e-5
+    coord = ProperMotionCalculator().calculate_positions(target, time, 10)
+    assert abs(coord.ra.deg[0] - 78.85740081) < 1e-5
+    assert abs(coord.dec.deg[0] - 15.63008372) < 1e-5

--- a/tests/unit/scheduler/services/horizons/test_horizons_client.py
+++ b/tests/unit/scheduler/services/horizons/test_horizons_client.py
@@ -60,9 +60,7 @@ def target() -> NonsiderealTarget:
         magnitudes=frozenset(),
         type=TargetType.BASE,
         tag=TargetTag.MAJOR_BODY,
-        des='jupiter',
-        ra=np.array([]),
-        dec=np.array([]))
+        des='jupiter')
 
 
 @pytest.fixture


### PR DESCRIPTION
This will be looked up using JPL/Horizons. It requires this lucupy update to work:
https://github.com/gemini-hlsw/lucupy/pull/102