### PR TITLE
GSCHED-710 modified visibility slot idx format

### DIFF
--- a/scheduler/services/visibility/snapshot.py
+++ b/scheduler/services/visibility/snapshot.py
@@ -8,6 +8,12 @@ from typing import final
 
 from lucupy.decorators import immutable
 from lucupy.minimodel import SkyBackground
+import itertools
+
+def group_ranges(i):
+    for _, b in itertools.groupby(enumerate(i), lambda pair: pair[1] - pair[0]):
+        b = list(b)
+        yield b[0][1], b[-1][1]
 
 
 @final
@@ -23,14 +29,16 @@ class VisibilitySnapshot:
 
     @staticmethod
     def from_dict(ti_dict: Dict) -> 'VisibilitySnapshot':
-        return VisibilitySnapshot(visibility_slot_idx=np.array(ti_dict['visibility_slot_idx'], dtype=int),
+        slot_list = [list(range(s[0], s[1] + 1)) for s in ti_dict['visibility_slot_idx']]
+        return VisibilitySnapshot(visibility_slot_idx=np.array([x for xs in slot_list for x in xs], dtype=int),
                                   visibility_time=TimeDelta(ti_dict['visibility_time']['value'],
                                                             format=ti_dict['visibility_time']['format']),
                                  )
 
     def to_dict(self) -> Dict:
+        visibility_ranges = group_ranges(self.visibility_slot_idx.tolist())
         return {
-            'visibility_slot_idx': self.visibility_slot_idx.tolist(),
+            'visibility_slot_idx': [*visibility_ranges],
             'visibility_time': {
                 'value': self.visibility_time.sec,
                 'format': self.visibility_time.format


### PR DESCRIPTION
Changed visibility data format to store data ranges in Redis instead of big lists.
Please be careful, this change may break things if Redis cache is not removed, since it is not compatible with the old format.

This change improves the timing in the schedule visibility calculation when using Redis data for the default parameters (semester visibility true and start date Oct 1, 2018) going from aprox 2 minutes to 1.5 minutes. Also the amount of stored data decreases to about a quarter of the original size.

Tests will fail if the Redis cache is not cleaned.