### PR TITLE
Added union types to handle subscription errors

### DIFF
--- a/scheduler/graphql_mid/types.py
+++ b/scheduler/graphql_mid/types.py
@@ -7,6 +7,7 @@ from typing import List, FrozenSet, Optional
 from zoneinfo import ZoneInfo
 
 import strawberry  # noqa
+from typing import Annotated, Union
 import astropy.units as u
 from astropy.coordinates import Angle
 from strawberry.scalars import JSON  # noqa
@@ -192,6 +193,11 @@ class NewNightPlans:
     night_plans: SNightTimelines
     plans_summary: JSON
 
+@strawberry.type
+class NightPlansError:
+    error: str
+
+NightPlansResponse = Annotated[Union[NewNightPlans, NightPlansError], strawberry.union("NightPlansResponse")]
 
 @strawberry.type
 class NewScheduleSuccess:


### PR DESCRIPTION
Strawberry default error handling was not working, since the websocket connection was killed and was not reconnecting, because a strange server state.
If the server is killed and restarted, the UI reconnects the socket correctly, but if an error kills the server, it is not able to comeback, then it seems better to catch the server exceptions and send them to the UI using union types.