### PR TITLE
Fix visibility_time format to match its value (both in seconds).

### DIFF
--- a/scheduler/services/visibility/calculator.py
+++ b/scheduler/services/visibility/calculator.py
@@ -293,7 +293,7 @@ class VisibilityCalculator(metaclass=Singleton):
             # Calculate the visibility time, the ongoing summed remaining visibility time, and
             # the remaining visibility fraction.
             # If the denominator for the visibility fraction is 0, use a value of 0.
-            visibility_time = len(visibility_slot_idx) * time_slot_length
+            visibility_time = TimeDelta(len(visibility_slot_idx) * time_slot_length.to_value(u.s), format='sec')
 
             visibility_snapshot = VisibilitySnapshot(visibility_slot_idx=visibility_slot_idx,
                                                      visibility_time=visibility_time)


### PR DESCRIPTION
Otherwise TimeDelta assumes a default format of 'jd', which will not match the value and visibility fraction factor in observation scores will be wrong.

This fix has not been tested because the calculated values have been used to fill the redis database, which I can't alter.  My understanding is that the redis database must be refilled using this fix.  Then we may have the observation scores calculated correctly.