### PR TITLE
Enabled with_redis boolean

### DIFF
--- a/scheduler/config.yaml
+++ b/scheduler/config.yaml
@@ -2,6 +2,7 @@ collector:
   observation_classes: [SCIENCE, PROGCAL, PARTNERCAL]
   program_types: [Q, LP, FT, DD]
   time_slot_length: 1.0 # on minutes
+  with_redis: true
 
 optimizer:
   name: GREEDYMAX

--- a/scheduler/core/builder/schedulerbuilder.py
+++ b/scheduler/core/builder/schedulerbuilder.py
@@ -38,12 +38,11 @@ class SchedulerBuilder(ABC):
                         num_of_nights: int,
                         sites: FrozenSet[Site],
                         semesters: FrozenSet[Semester],
-                        with_redis: bool,
                         blueprint: CollectorBlueprint,
                         program_list: Optional[bytes] = None) -> Collector:
         # TODO: Removing sources from Collector I think it was an idea
         # TODO: we might want to implement so all these are static methods.
-        collector = Collector(start, end, num_of_nights, sites, semesters, self.sources, with_redis, *blueprint)
+        collector = Collector(start, end, num_of_nights, sites, semesters, self.sources, *blueprint)
         return collector
 
     @staticmethod

--- a/scheduler/core/builder/validationbuilder.py
+++ b/scheduler/core/builder/validationbuilder.py
@@ -88,11 +88,10 @@ class ValidationBuilder(SchedulerBuilder):
                         num_of_nights: int,
                         sites: FrozenSet[Site],
                         semesters: FrozenSet[Semester],
-                        with_redis: bool,
                         blueprint: CollectorBlueprint,
                         program_list: Optional[bytes] = None) -> Collector:
 
-        collector = super().build_collector(start, end, num_of_nights, sites, semesters, with_redis, blueprint)
+        collector = super().build_collector(start, end, num_of_nights, sites, semesters, blueprint)
         collector.load_programs(program_provider_class=OcsProgramProvider, data=ocs_program_data(program_list))
         ValidationBuilder.reset_collector_observations(collector)
         return collector

--- a/scheduler/engine/engine.py
+++ b/scheduler/engine/engine.py
@@ -26,7 +26,6 @@ __all__ = [
     'Engine'
 ]
 
-from ..core.output import print_plans
 from ..core.statscalculator.run_summary import RunSummary
 
 _logger = logger_factory.create_logger(__name__)
@@ -242,7 +241,6 @@ class Engine:
                                             num_of_nights=self.params.num_nights_to_schedule,
                                             sites=self.params.sites,
                                             semesters=self.params.semesters,
-                                            with_redis=True,
                                             blueprint=Blueprints.collector,
                                             program_list=self.params.programs_list)
 

--- a/scheduler/services/redis_client/redis_client.py
+++ b/scheduler/services/redis_client/redis_client.py
@@ -44,6 +44,16 @@ class RedisClient(metaclass=Singleton):
             d[parts[-1]] = json.loads(value)
         return result
 
+    @staticmethod
+    def transform_to_json(vis_table):
+        # Transform to json, TargetVisibilityTable -> JSON
+        flat_dict = RedisClient.flatten_dict(vis_table)
+        pipeline = dict(flat_dict)
+
+        for i, (k, v) in enumerate(flat_dict.items(), 1):
+            pipeline[k] = json.dumps(v.to_dict())
+        return RedisClient.unflatten_dict(pipeline)
+
     async def get_nested_value(self, main_key: str, key: str) -> Optional[dict]:
         value = await self._redis_client.hget(main_key, key)
         return json.loads(value) if value else None

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -45,7 +45,6 @@ def scheduler_collector():
         num_of_nights=num_nights_to_schedule,
         sites=sites,
         semesters=semesters,
-        with_redis=True,
         blueprint=collector_blueprint
     )
 


### PR DESCRIPTION
In the `config.yaml` file the parameter `with_redis` will be found and can be used to disable redis.
The visibility calculations are done in the collector and just for the programs needed in the requested plan, which is different from the information retrieved from Redis that stores a full list of programsfor the semester, calculatiing the full list locally at startup means a huge overhead.