### PR TITLE
Coords should not be stored after calculations

### DIFF
--- a/scheduler/core/calculations/targetinfo.py
+++ b/scheduler/core/calculations/targetinfo.py
@@ -46,7 +46,8 @@ class TargetInfo:
     rem_visibility_time is the remaining visibility time for the target for the observation across
     the rest of the time period.
     """
-    coord: SkyCoord
+    max_dec: Angle
+    min_dec: Angle
     alt: Angle
     az: Angle
     hourangle: Angle

--- a/scheduler/core/components/collector/collector.py
+++ b/scheduler/core/components/collector/collector.py
@@ -302,7 +302,8 @@ class Collector(SchedulerComponent):
                                                         for_vis_calc= False)
             ts = target_vis[night_idx]
 
-            ti = TargetInfo(coord=target_snapshot.coord,
+            ti = TargetInfo(max_dec=target_snapshot.max_dec,
+                            min_dec=target_snapshot.min_dec,
                             alt=target_snapshot.alt,
                             az=target_snapshot.az,
                             hourangle=target_snapshot.hourangle,

--- a/scheduler/core/components/ranker/default.py
+++ b/scheduler/core/components/ranker/default.py
@@ -15,8 +15,6 @@ from lucupy.types import ListOrNDArray, MinMax
 # from scheduler.core.calculations import Scores, GroupDataMap
 from .base import Ranker
 
-import pdb
-
 __all__ = [
     'DefaultRanker',
     'RankerParameters',

--- a/scheduler/core/components/ranker/default.py
+++ b/scheduler/core/components/ranker/default.py
@@ -15,6 +15,8 @@ from lucupy.types import ListOrNDArray, MinMax
 # from scheduler.core.calculations import Scores, GroupDataMap
 from .base import Ranker
 
+import pdb
+
 __all__ = [
     'DefaultRanker',
     'RankerParameters',
@@ -267,18 +269,15 @@ class DefaultRanker(Ranker):
                                               np.array([0.8]),
                                               program.thesis)
 
-        # Declination for the base target per night.
-        dec = {night_idx: target_info[night_idx].coord.dec for night_idx in self.night_indices}
-
         # Hour angle / airmass
         ha = {night_idx: target_info[night_idx].hourangle for night_idx in self.night_indices}
 
         # Get the latitude associated with the site.
         site_latitude = obs.site.location.lat
         if site_latitude < 0. * u.deg:
-            dec_diff = {night_idx: np.abs(site_latitude - np.max(dec[night_idx])) for night_idx in self.night_indices}
+            dec_diff = {night_idx: np.abs(site_latitude - target_info[night_idx].max_dec) for night_idx in self.night_indices}
         else:
-            dec_diff = {night_idx: np.abs(np.min(dec[night_idx]) - site_latitude) for night_idx in self.night_indices}
+            dec_diff = {night_idx: np.abs(target_info[night_idx].min_dec - site_latitude) for night_idx in self.night_indices}
 
         c = {night_idx: self.params.dec_diff_less_40 if angle < 40. * u.deg else self.params.dec_diff
              for night_idx, angle in dec_diff.items()}

--- a/scheduler/services/visibility/calculator.py
+++ b/scheduler/services/visibility/calculator.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import final, Dict, List, Any, Optional, ClassVar, FrozenSet
+from typing import final, Dict, List, Any, Optional, ClassVar, FrozenSet, Generator
 
 import astropy.units as u
 import numpy as np
@@ -117,7 +117,9 @@ def calculate_target_snapshot(night_idx: NightIndex,
             targ_sb = SkyBackground.SBANY
             sb = np.full([len(night_events.times[night_idx])], SkyBackground.SBANY)
 
-        return TargetSnapshot(coord=coord,
+
+        return TargetSnapshot(max_dec=np.max(coord.dec),
+                              min_dec=np.min(coord.dec),
                               alt=alt,
                               az=az,
                               par_ang=par_ang,
@@ -126,7 +128,8 @@ def calculate_target_snapshot(night_idx: NightIndex,
                               target_sb=targ_sb,
                               sky_brightness=sb)
     else:
-        return TargetSnapshot(coord=coord,
+        return TargetSnapshot(max_dec=np.max(coord.dec),
+                              min_dec=np.min(coord.dec),
                               alt=alt,
                               az=az,
                               hourangle=hourangle,

--- a/scheduler/services/visibility/snapshot.py
+++ b/scheduler/services/visibility/snapshot.py
@@ -60,7 +60,8 @@ class TargetSnapshot:
     Contains information of a target for a night.
     All values except target_sb are numpy arrays (shape == time_slots).
     """
-    coord: SkyCoord
+    max_dec: Angle
+    min_dec: Angle
     alt: Angle
     az: Angle
     hourangle: Angle


### PR DESCRIPTION
Checking the entire scripts I notice after the `target_snapshot` calculation, the coords were used only once to get the max and min dec for each night.
I modified to store the single max and min values instead of coords and the memory usage in the last test I ran using full semester visibility, 7 night plan, GN only and full program list, decreased from ~17GB to ~9GB.