### PR TITLE
Coarse time grid bug fixes

### DIFF
--- a/scheduler/scripts/hours_up.py
+++ b/scheduler/scripts/hours_up.py
@@ -169,8 +169,10 @@ def hours_up(obsid: ObservationID, night_idx: int, airmass_max=2.05):
     # Get target info from observation
     obs = collector.get_observation(obsid)
     ti = collector.get_target_info(obs.id)
-    ra = ti[0].coord.ra[0]
-    dec = ti[0].coord.dec[0]
+    # ra = ti[0].coord.ra[0]
+    # dec = ti[0].coord.dec[0]
+    ra = ti[0].coord.ra
+    dec = ti[0].coord.dec
     # print(ra, dec)
 
     # Get the site info


### PR DESCRIPTION
These fixes should allow us to run the scheduler on an arbitrary integer minute time grid. It's been tested using 5 minute time slots.  To change this in Heroku we need to update time_slot_length in config.yaml and then repopulate the redis cache. 