### PR TITLE
GSCHED-833: ongoing score boost, ranker night_indices bug fix

### DIFF
--- a/scheduler/core/components/ranker/base.py
+++ b/scheduler/core/components/ranker/base.py
@@ -64,7 +64,8 @@ class Ranker(ABC):
             raise ValueError('Ranker group scoring can only score groups.')
 
     @abstractmethod
-    def score_observation(self, program: Program, obs: Observation, night_configurations: dict):
+    def score_observation(self, program: Program, obs: Observation, night_configurations: dict,
+                          night_indices: NightIndices):
         """
         Calculate the scores for an observation for each night for each time slot index.
         These are returned as a list indexed by night index as per the night_indices supplied,

--- a/scheduler/core/components/selector/selector.py
+++ b/scheduler/core/components/selector/selector.py
@@ -514,7 +514,7 @@ class Selector(SchedulerComponent):
                 schedulable_slot_indices[night_idx] = np.array([])
         # print(f'number schedulable slots night: {len(schedulable_slot_indices[night_idx])}')
 
-        obs_scores = ranker.score_observation(program, obs, self.night_configurations)
+        obs_scores = ranker.score_observation(program, obs, self.night_configurations, night_indices)
         # print(f'obs_scores: {max(obs_scores[night_idx])}')
 
         # Calculate the scores for the observation across all night indices across all timeslots.


### PR DESCRIPTION
Adds a new factor to increase the score for ongoing observations.

Fixes a bug that improves the ranker performance. The ranker is currently instantiated in engine.build, making ranker.night_indices include all the nights to schedule. Therefore, the ranker was looping over all those nights every time it was called. I added a night_indices parameter to ranker.score_observation so that it would only score the one night being treated by the selector. The ranker instantiation is the same so that the arrays are zeroed and the metric_score is defined for later use. There may be a better way to do this but it was simple and it works. We can do more fundamental refactoring for real-time mode.