### PR TITLE
Stop time accounting for most events when site is blocked by InterruptionEvent

### DIFF
--- a/scheduler/core/events/cycle/cycle.py
+++ b/scheduler/core/events/cycle/cycle.py
@@ -68,20 +68,6 @@ class EventCycle:
             end_timeslot_bounds=end_timeslot_bounds
         )
 
-        if update.done:
-            # For morning twilight, add final plan showing all observations
-            _logger.debug('Night done. Wrapping up final plan')
-            final_plan = nightly_timeline.get_final_plan(NightIndex(night_idx),
-                                                        site,
-                                                        self.change_monitor.is_site_unblocked(site))
-            nightly_timeline.add(
-                NightIndex(night_idx),
-                site,
-                current_timeslot,
-                update.event,
-                final_plan
-            )
-
     def _create_new_plan(self,
                          site: Site,
                          night_idx: NightIndex,
@@ -240,8 +226,22 @@ class EventCycle:
                     nightly_timeline
                 )
 
-            # Get a new selection and request a new plan if the night is not done
-            if not update.done:
+            # If the night is done, get a final plan and add it to the timeline.
+            # Otherwise, get a new selection and request a new plan
+            if update.done:
+                _logger.debug('Night done. Wrapping up final plan')
+                final_plan = nightly_timeline.get_final_plan(NightIndex(night_idx),
+                                                             site,
+                                                             self.change_monitor.is_site_unblocked(site))
+                nightly_timeline.add(
+                    NightIndex(night_idx),
+                    site,
+                    current_timeslot,
+                    update.event,
+                    final_plan
+                )
+                
+            else:
                 plans = self._create_new_plan(
                     site,
                     night_idx,

--- a/scheduler/core/events/queue/nightchanges.py
+++ b/scheduler/core/events/queue/nightchanges.py
@@ -155,10 +155,11 @@ class NightlyTimeline:
         for entry in self.timeline[night_idx][site]:
             event = entry.event
             if isinstance(event, MorningTwilightEvent):
-                unschedule = entry.plan_generated.time_left() - weather - fault
-                #  if unschedule < 0:
-                #    raise ValueError(f'Unscheduled time is negative!')
-                self.time_losses[night_idx][site]["unschedule"] = unschedule
+                if entry.plan_generated is not None:
+                    unschedule = entry.plan_generated.time_left() - weather - fault
+                    #  if unschedule < 0:
+                    #    raise ValueError(f'Unscheduled time is negative!')
+                    self.time_losses[night_idx][site]["unschedule"] = unschedule
 
         self.time_losses[night_idx][site]["weather"] = weather
         self.time_losses[night_idx][site]["fault"] = fault


### PR DESCRIPTION
In the ChangeMonitor, WeatherChangeEvents during an interruption should not result in time accounting (time accounting would have been updated by the InterruptionEvent and no observations taken since).  This caused a problem because the end_timeslot_charge was getting set to each new event timeslot and causing observations during the interruption to get counted as observed.  For InterruptionEvents, time accounting should be done if there's not already another InterruptionEvent in place.  Similarly, at morning twilight, the time accounting should be done if the site is not blocked.

In the EventCycle, separate the creation of a final plan from time accounting so that, at morning twilight, when no time accounting should be done (ie. probably because of an InterruptionEvent), a final plan can still be created.

A new problem appears if an InterruptionEvent occurs before EveningTwilightEvent.  An example is Gemini South on UT 2018-10-10.  On that night/site, the InterruptionEvent is 5 seconds before EveningTwilightEvent (both at timeslot 0).  The SortedKeyList where they are stored ensures they are ordered by time.  In that case, and with these changes, no partial plan is created at evening twilight.  In fact, no partial plan is created at all this night and there is not a final plan either (closed all night).  This doesn't seem normal, but I'm unsure of the use of the final plan or what it is intended to represent.  To get accommodate this case, I had to modify the calculate_time_losses in NightlyTimeline to check for no final plan at the MorningTwilightEvent.  On other closed nights that I tested, the closure starts ~1 minute past evening twilight and there is a partial plan made to start the night (and then final plan too, based on that).

