### PR TITLE
Fix problem parsing the start/end dates of a few FT programs.

### DIFF
--- a/scheduler/core/programprovider/ocs/ocsprogramprovider.py
+++ b/scheduler/core/programprovider/ocs/ocsprogramprovider.py
@@ -369,7 +369,7 @@ class OcsProgramProvider(ProgramProvider):
                 # Convert month data as above to a list of months.
                 curr_note_title = curr_note_title.strip().replace('and ', ' ')\
                     .replace('  ', ' ').replace(', ', '-').replace(';', '')\
-                    .replace('(', '').replace(')', '')
+                    .replace('(', '').replace(')', '').replace('Cycle:','')
                 # curr_note_months = curr_note_title.split(' ')[-1].lower()
                 # Can't assume that the months are in the last element of the split title, key on '-'
                 curr_note_months = [val.lower() for val in curr_note_title.split(' ') if '-' in val][0]
@@ -378,7 +378,7 @@ class OcsProgramProvider(ProgramProvider):
                 # print(f'\t{month_list}')
                 # print(f'{program_id.id}: month_list {month_list}')
                 if len(month_list) < 3:
-                    msg = (f'Error parsing active note title for FT program {id}. '
+                    msg = (f'Error parsing active note title for FT program {program_id}. '
                            f'Check month names/abreviations or extra dashes.')
                     raise ValueError(msg)
                 m1 = month_number(month_list[0], months_list)
@@ -398,7 +398,7 @@ class OcsProgramProvider(ProgramProvider):
             # Find the note (if any) that contains the information.
             note_title = next(filter(is_ft_note, note_titles), None)
             if note_title is None:
-                msg = f'Fast turnaround program {id} has no note containing start / end date information.'
+                msg = f'Fast turnaround program {program_id} has no note containing start / end date information.'
                 raise ValueError(msg)
 
             # Parse the month information.
@@ -406,7 +406,7 @@ class OcsProgramProvider(ProgramProvider):
                 date_info = parse_dates(note_title)
 
             except IndexError as e:
-                msg = f'Fast turnaround program {id} note title has improper form: {note_title}.'
+                msg = f'Fast turnaround program {program_id} note title has improper form: {note_title}.'
                 raise ValueError(e, msg)
 
             start_date, end_date = date_info


### PR DESCRIPTION
This branch is not working in the current scheduler on my laptop!!! It appears like the problem is missing visibility data in the Redis DB.  If the program parsing problem prevented certain programs from being stored there, this might make sense.

Four programs are affected where the note title has no whitespace between the string 'Cycle:' and the months of visibility.  E.g., 'Cycle:Dec-Jan-Feb'.  Also replace undefined value in a few logger statements in the _get_program_dates method.