### PR TITLE
GSCHED-860: Add RT endpoint for XT1 testing

### DIFF
--- a/scheduler/graphql_mid/schema.py
+++ b/scheduler/graphql_mid/schema.py
@@ -4,8 +4,10 @@ import asyncio
 from os import environ
 from typing import List, AsyncGenerator, Dict
 
+import numpy as np
 import strawberry # noqa
 from astropy.time import Time
+from lucupy.minimodel import TimeslotIndex, NightIndex, VariantSnapshot, ImageQuality, CloudCover
 from lucupy.minimodel.site import Site
 from scheduler.context import schedule_id_var
 from scheduler.core.components.ranker import RankerParameters
@@ -13,9 +15,11 @@ from scheduler.engine import Engine, SchedulerParameters
 from scheduler.services.logger_factory import create_logger
 from scheduler.config import config
 
-from .types import (SPlans, SNightTimelines, NewNightPlans, NightPlansError, NightPlansResponse, Version, SRunSummary)
+from .types import (SPlans, SNightTimelines, NewNightPlans, NightPlansError, NightPlansResponse, Version, SRunSummary,
+                    NewPlansRT, NightPlansResponseRT)
 from .inputs import CreateNewScheduleInput
-
+from ..core.plans import NightStats
+from ..core.statscalculator import StatCalculator
 
 _logger = create_logger(__name__)
 
@@ -29,6 +33,31 @@ def sync_schedule(params: SchedulerParameters) -> NewNightPlans:
     s_plan_summary = SRunSummary.from_computed_run_summary(plan_summary)
     return NewNightPlans(night_plans=s_timelines, plans_summary=s_plan_summary)
 
+def sync_rt_schedule(params: SchedulerParameters) -> NewPlansRT:
+    engine = Engine(params)
+    scp = engine.build()
+
+    site = list(params.sites)[0]
+    initial_variant = scp.collector.sources.origin.env.get_initial_conditions(
+        site,
+        params.start.to_datetime().date()
+    )
+
+    scp.selector.update_site_variant(site, initial_variant)
+    plans = scp.run(site, np.array([NightIndex(0)]), TimeslotIndex(0))
+
+    plans.plans[site].night_stats = NightStats({},0.0,0,{},{})
+    plans.plans[site].alt_degs = []
+    # Calculate altitude data
+    for visit in plans.plans[site].visits:
+        ti = scp.collector.get_target_info(visit.obs_id)
+        end_time_slot = visit.start_time_slot + visit.time_slots
+        values = ti[plans.night_idx].alt[visit.start_time_slot: end_time_slot]
+        alt_degs = [val.dms[0] + (val.dms[1] / 60) + (val.dms[2] / 3600) for val in values]
+        plans.plans[site].alt_degs.append(alt_degs)
+    splans = SPlans.from_computed_plans(plans, params.sites)
+
+    return NewPlansRT(night_plans=splans)
 
 active_subscriptions: Dict[str, asyncio.Queue] = {}
 
@@ -39,6 +68,42 @@ class Query:
     @strawberry.field
     def version(self) -> Version:
         return Version(version=environ['APP_VERSION'], changelog=config.app.changelog)
+
+    @strawberry.field
+    async def schedule_rt(self, schedule_id: str, new_schedule_input: CreateNewScheduleInput) -> str:
+        #TODO: replace with the rt schedule input
+        start = Time(new_schedule_input.start_time, format='iso', scale='utc')
+        end = Time(new_schedule_input.end_time, format='iso', scale='utc')
+        ranker_params = RankerParameters(new_schedule_input.thesis_factor,
+                                         new_schedule_input.power,
+                                         new_schedule_input.met_power,
+                                         new_schedule_input.vis_power,
+                                         new_schedule_input.wha_power,
+                                         new_schedule_input.air_power)
+
+        programs_list = None
+        if new_schedule_input.programs:
+            if len(new_schedule_input.programs) > 0:
+                programs_list = new_schedule_input.programs
+
+        params = SchedulerParameters(start,
+                                     end,
+                                     new_schedule_input.sites,
+                                     new_schedule_input.mode,
+                                     ranker_params,
+                                     new_schedule_input.semester_visibility,
+                                     new_schedule_input.num_nights_to_schedule,
+                                     programs_list)
+        task = asyncio.to_thread(sync_rt_schedule, params)
+        if schedule_id not in active_subscriptions:
+            queue = asyncio.Queue()
+            active_subscriptions[schedule_id] = queue
+        else:
+            queue = active_subscriptions[schedule_id]
+
+        await queue.put(task)
+        return f'Plan is on the queue! for {schedule_id}'
+
 
     @strawberry.field
     async def schedule(self, schedule_id: str, new_schedule_input: CreateNewScheduleInput) -> str:
@@ -81,7 +146,7 @@ class Query:
 @strawberry.type
 class Subscription:
     @strawberry.subscription
-    async def queue_schedule(self, schedule_id: str) -> AsyncGenerator[NightPlansResponse, None]:
+    async def queue_schedule(self, schedule_id: str) -> AsyncGenerator[NightPlansResponseRT, None]:
         schedule_id_var.set(schedule_id)
         if schedule_id not in active_subscriptions:
             queue = asyncio.Queue()

--- a/scheduler/graphql_mid/types.py
+++ b/scheduler/graphql_mid/types.py
@@ -2,7 +2,7 @@
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 from datetime import datetime, timedelta
-from typing import List, FrozenSet, Optional
+from typing import List, FrozenSet, Optional, Dict
 from zoneinfo import ZoneInfo
 
 import strawberry  # noqa
@@ -207,10 +207,16 @@ class NewNightPlans:
     plans_summary: SRunSummary
 
 @strawberry.type
+class NewPlansRT:
+    night_plans: SPlans
+
+@strawberry.type
 class NightPlansError:
     error: str
 
 NightPlansResponse = Annotated[Union[NewNightPlans, NightPlansError], strawberry.union("NightPlansResponse")]
+
+NightPlansResponseRT = Annotated[Union[NightPlansResponse, NewPlansRT], strawberry.union("NightPlansResponseRT")]
 
 @strawberry.type
 class NewScheduleSuccess:


### PR DESCRIPTION
New query-sub pair:

RTquery:
```
query Schedule {
  scheduleRt(
    scheduleId: "12"
    newScheduleInput: {startTime: "2018-12-02 08:00:00", endTime: "2018-12-08 08:00:00", sites: "GS", mode: VALIDATION, semesterVisibility: false, numNightsToSchedule: 1}
  )
}

```
RTSub (this one remains the same but it adds the typename NewPlansRT):

```
subscription QueueSchedule {
  queueSchedule(scheduleId: "12") {
    __typename
    ... on NewNightPlans {
      nightPlans {
        nightTimeline {
          nightIndex
          timeEntriesBySite {
            site
            timeLosses
            timeEntries {
              event
              plan {
                startTime
                endTime
                nightConditions {
                  iq
                  cc
                }
                visits {
                  obsId
                }
                nightStats {
                  planScore
                  timeLoss
                }
              }
            }
          }
        }
      }
      plansSummary {
        metricsPerBand
        summary
      }
    }
    ... on NightPlansError {
      error
    }
    ... on NewPlansRT {
      nightPlans {
        plansPerSite {
          startTime
          endTime
          nightConditions {
            iq
            cc
          }
          visits {
            obsId
          }
          nightStats {
            planScore
            timeLoss
          }
        }
      }
    }
  }
}
```
