### PR TITLE
Update night start and night end event if needed

### DIFF
--- a/scheduler/core/components/nighteventsmanager/nighteventsmanager.py
+++ b/scheduler/core/components/nighteventsmanager/nighteventsmanager.py
@@ -49,4 +49,16 @@ class NightEventsManager(metaclass=Singleton):
             )
             NightEventsManager._night_events[data_id] = night_events
 
+        # Check if night lenght was modified
+        elif night_start_time != NightEventsManager._night_events[data_id].night_start_time or \
+                night_end_time != NightEventsManager._night_events[data_id].night_end_time:
+            NightEventsManager._night_events[data_id] = NightEvents(
+                time_grid,
+                night_start_time,
+                night_end_time,
+                time_slot_length,
+                site,
+                *sky.night_events(time_grid, site.location, site.timezone)
+            )
+
         return NightEventsManager._night_events[data_id]


### PR DESCRIPTION
This change is needed to be able to re-run using the same data but changing the night length.
Without this change, only the first received night length will be used while the scheduler instance is running.