### PR TITLE
fix(backend): Fix time accounting of incomplete AND groups

### DIFF
--- a/backend/scheduler/core/components/collector/collector.py
+++ b/backend/scheduler/core/components/collector/collector.py
@@ -756,10 +756,10 @@ class Collector(SchedulerComponent):
                             slot_atom_start = slot_atom_end - slot_atom_length
 
                         if slot_atom_end < end_timeslot_charge:
-
-                            atom_record = self.time_accountant.get_record(observation, obs_seq[atom_idx])
                             if charge_group:
                                 # Charge to program or partner
+                                atom_record = self.time_accountant.get_record(observation, obs_seq[atom_idx])
+
                                 obs_seq[atom_idx].program_used = obs_seq[atom_idx].prog_time
                                 obs_seq[atom_idx].partner_used = obs_seq[atom_idx].part_time
 
@@ -783,6 +783,8 @@ class Collector(SchedulerComponent):
 
                             elif not_charged:
                                 # charge to not_charged
+                                atom_record = self.time_accountant.get_record(observation, obs_seq[atom_idx])
+
                                 not_charged_time = (end_timeslot_charge -
                                                     slot_atom_start + 1) * self.time_slot_length.to_datetime()
                                 obs_seq[atom_idx].not_charged += not_charged_time

--- a/changelog.d/GSCHED-963.fix.md
+++ b/changelog.d/GSCHED-963.fix.md
@@ -1,0 +1,1 @@
+Fix time accounting record in Collector. making incomplete AND groups showing up in final plan


### PR DESCRIPTION
<!-- CHANGELOG:START -->
### Changelog

**fix** (GSCHED-963): Fix time accounting record in Collector. making incomplete AND groups showing up in final plan
<!-- CHANGELOG:END -->

## Scope

<!-- CI auto-detects this, but it helps reviewers to see at a glance. -->

- [x] Backend (`backend/`)
- [ ] Frontend (`frontend/`)
- [ ] Docs (`docs/`)
- [ ] CI/Infra (`.github/`)


<!-- 
  REQUIRED: Add a changelog fragment file to this PR.
  
  Quickest way (auto-detects ticket from branch name):
    ./scripts/changelog-fragment "Your change description"
    ./scripts/changelog-fragment "Your change description" fix
    ./scripts/changelog-fragment "" misc

  Manual:
    echo "Description" > changelog.d/GSCHED-190.feature.md

  Types: feature, fix, breaking, deprecation, improvement, doc, misc
  CI will fail if no fragment is found (unless only CI/docs files changed).
-->


## Jira

<!-- JIRA:START -->
[GSCHED-963](https://noirlab.atlassian.net/browse/GSCHED-963)
<!-- JIRA:END -->

## Checklist

- [x] Changelog fragment added to `changelog.d/`
- [x] Commit messages follow conventional commits (`feat(backend):`, `fix(frontend):`, etc.)
- [x] No breaking changes (or `breaking` fragment added)
