### PR TITLE
fix(backend): Root group changed to folder/OR, GM pseudo time-accounting updates

### DIFF
--- a/backend/scheduler/core/components/optimizer/greedymax.py
+++ b/backend/scheduler/core/components/optimizer/greedymax.py
@@ -809,6 +809,19 @@ class GreedyMaxOptimizer(BaseOptimizer):
                     schedulable_group.group_info.scores = group_info.scores
                     # schedulable_group.group_info.scores[:] = group_info.scores[:]
                 # print(f"\tUpdated max score: {np.max(schedulable_group.group_info.scores[night_idx]):7.2f}")
+        else:
+            # All the time has been used, remove any remaining groups from this program
+            # ToDo: may need to check that all the necessary calibrations are taken, or do this check up front
+            #  (in the Ranker?)
+            # print(f'{program.id.id} is out of time')
+            logger.info(f'{program.id.id} is out of time')
+            for unique_group_id in self.group_ids:
+                # print(unique_group_id.id)
+                group_data = self.selection.schedulable_groups[unique_group_id]
+                if program.id == group_data.group.program_id and group_data in self.group_data_list:
+                    # print(f'\t Removing {unique_group_id.id}')
+                    logger.info(f'\t Removing {unique_group_id.id}')
+                    self.group_data_list.remove(group_data)
 
 
     def _update_group_list(self, max_group_info: MaxGroup, night_idx: NightIndex):

--- a/backend/scheduler/core/components/ranker/default.py
+++ b/backend/scheduler/core/components/ranker/default.py
@@ -268,15 +268,11 @@ class DefaultRanker(Ranker):
         if target_info is None:
             return scores
 
-        # Restrict to nights this observation is actually visible on. Sight populates
-        # target_info only for visible (obs, night) pairs; iterating night_indices
-        # blindly would KeyError on the rest. `scores` is already pre-zero-padded
-        # for every night via _empty_obs_scores, so non-visible nights remain zero.
-        obs_nights = sorted(set(night_indices) & target_info.keys())
-        if not obs_nights:
-            return scores
-
+        # Remaining time in the observation
         remaining = obs.exec_time() - obs.total_used()
+
+        # Completeness if the observation is done
+        # ToDo: consider whether we should be scheduling if cplt > 1 (buffer considered), may need a group check
         # GPP supports allocated and used times by band, this should give the same results for OCS
         cplt = (program.total_used(obs.band) + remaining) / program.total_awarded(obs.band)
 
@@ -288,18 +284,18 @@ class DefaultRanker(Ranker):
         #       f"metric={metric[0]}")
 
         # Declination for the base target per night.
-        dec = {night_idx: target_info[night_idx].coord.dec for night_idx in obs_nights}
+        dec = {night_idx: target_info[night_idx].coord.dec for night_idx in night_indices}
 
         # Hour angle / airmass
-        ha = {night_idx: target_info[night_idx].hourangle for night_idx in obs_nights}
-        airmass = {night_idx: target_info[night_idx].airmass for night_idx in obs_nights}
+        ha = {night_idx: target_info[night_idx].hourangle for night_idx in night_indices}
+        airmass = {night_idx: target_info[night_idx].airmass for night_idx in night_indices}
 
         # Get the latitude associated with the site.
         site_latitude = obs.site.location.lat
         if site_latitude < 0. * u.deg:
-            dec_diff = {night_idx: np.abs(site_latitude - np.max(dec[night_idx])) for night_idx in obs_nights}
+            dec_diff = {night_idx: np.abs(site_latitude - np.max(dec[night_idx])) for night_idx in night_indices}
         else:
-            dec_diff = {night_idx: np.abs(np.min(dec[night_idx]) - site_latitude) for night_idx in obs_nights}
+            dec_diff = {night_idx: np.abs(np.min(dec[night_idx]) - site_latitude) for night_idx in night_indices}
 
         c = {night_idx: self.params.dec_diff_less_40 if angle < 40. * u.deg else self.params.dec_diff
              for night_idx, angle in dec_diff.items()}
@@ -308,19 +304,19 @@ class DefaultRanker(Ranker):
 
         wha = {night_idx: c[night_idx][0] + c[night_idx][1] * ha[night_idx] / u.hourangle
                + (c[night_idx][2] / u.hourangle ** 2) * ha[night_idx] ** 2
-               for night_idx in obs_nights}
-        kk = {night_idx: np.where(wha[night_idx] <= 0.)[0] for night_idx in obs_nights}
-        for night_idx in obs_nights:
+               for night_idx in night_indices}
+        kk = {night_idx: np.where(wha[night_idx] <= 0.)[0] for night_idx in night_indices}
+        for night_idx in night_indices:
             wha[night_idx][kk[night_idx]] = 0.
         # print(f'   max wha: {np.max(wha[0]):.2f}  visfrac: {target_info[0].rem_visibility_frac:.5f}')
 
         # Telescope altitude restrictions - set score to 0 if the altitude is outside the limits
-        targ_alt = {night_idx: target_info[night_idx].alt for night_idx in obs_nights}
-        alt_include = {night_idx: np.ones(len(targ_alt[night_idx])) for night_idx in obs_nights}
+        targ_alt = {night_idx: target_info[night_idx].alt for night_idx in night_indices}
+        alt_include = {night_idx: np.ones(len(targ_alt[night_idx])) for night_idx in night_indices}
         jj = {night_idx: np.where(np.logical_or(targ_alt[night_idx] < self.params.altitude_limits[obs.site][MinMax.MIN],
                                                  targ_alt[night_idx] > self.params.altitude_limits[obs.site][MinMax.MAX]))[0]
-              for night_idx in obs_nights}
-        for night_idx in obs_nights:
+              for night_idx in night_indices}
+        for night_idx in night_indices:
             alt_include[night_idx][jj[night_idx]] = 0.0
 
         # Scale factor terms: preimaging * user priority * ongoing * prog priority
@@ -346,7 +342,7 @@ class DefaultRanker(Ranker):
         nc = night_configurations[obs.site]
         program = self.collector.get_program(obs.id.program_id())
         prog_priority = {night_idx: self.params.program_priority if nc[night_idx].filter.program_priority_filter_any(program)
-                         else 1.0 for night_idx in obs_nights}
+                         else 1.0 for night_idx in night_indices}
         scale_factor *= prog_priority[night_idx]
 
         # Divide by the minimum airmass (mainly for cross-site scoring tests)
@@ -354,11 +350,11 @@ class DefaultRanker(Ranker):
                         (target_info[night_idx].rem_visibility_frac ** self.params.vis_power) *
                         (wha[night_idx] ** self.params.wha_power) * alt_include[night_idx] /
                         (np.min(airmass[night_idx]) ** self.params.air_power)
-             for night_idx in obs_nights}
+             for night_idx in night_indices}
 
         # Assign scores in p to all indices where visibility constraints are met.
         # They will otherwise be 0 as originally defined.
-        for night_idx in obs_nights:
+        for night_idx in night_indices:
             slot_indices = target_info[night_idx].visibility_slot_idx
             # if 'Q-224' in obs.id.id:
             #     print(obs.id.id, night_idx, np.max(p[night_idx]), priority_value, len(slot_indices))

--- a/backend/scheduler/core/components/selector/timebuffer.py
+++ b/backend/scheduler/core/components/selector/timebuffer.py
@@ -54,7 +54,7 @@ class PercentageTimeBuffer(TimeBuffer):
     percentage: float
 
     def _calculate_time(self, p: Program) -> timedelta:
-        return p.program_awarded() * (1.0 + self.percentage)
+        return p.program_awarded() * self.percentage
 
 
 @final
@@ -84,7 +84,7 @@ def create_time_buffer(buffer_type_str: str,
             return NoTimeBuffer()
 
         case TimeBufferType.PERCENTAGE:
-            if buffer_amount is None or not (0 < buffer_amount < 1):
+            if buffer_amount is None or not (0 <= buffer_amount <= 1):
                 raise ConfigurationError('buffer_amount', str(buffer_amount))
             return PercentageTimeBuffer(buffer_amount)
 

--- a/backend/scheduler/core/programprovider/gpp/gppprogramprovider.py
+++ b/backend/scheduler/core/programprovider/gpp/gppprogramprovider.py
@@ -1234,7 +1234,7 @@ class GppProgramProvider(ProgramProvider):
             group_name = ROOT_GROUP_ID.id
             delay_min = None
             delay_max = None
-            group_option = AndOption.ANYORDER
+            group_option = AndOption.NONE  # Treat as a folder, which is an OR group with all observations needed
             number_observed = 0
             elements_list = data[GppProgramProvider._GroupKeys.ELEMENTS]
             number_to_observe = len(elements_list)

--- a/backend/scheduler/core/programprovider/ocs/ocsprogramprovider.py
+++ b/backend/scheduler/core/programprovider/ocs/ocsprogramprovider.py
@@ -1282,7 +1282,7 @@ class OcsProgramProvider(ProgramProvider):
             group_name = data[OcsProgramProvider._GroupKeys.GROUP_NAME]
         else:
             group_name = ROOT_GROUP_ID.id
-            group_option = AndOption.ANYORDER
+            group_option = AndOption.NONE
 
         # Parse notes for "do not split" information if not found previously
         notes = [(data[key][OcsProgramProvider._NoteKeys.TITLE], data[key][OcsProgramProvider._NoteKeys.TEXT])

--- a/changelog.d/GSCHED-977.fix.md
+++ b/changelog.d/GSCHED-977.fix.md
@@ -1,0 +1,1 @@
+Root group changed to folder/OR, GM pseudo time-accounting updates


### PR DESCRIPTION
Investigated the issue that Diego reported with the scoring of G-2026A-0166-Q in dev
https://nationalastro.slack.com/archives/C08UDCUGH5Z/p1779999133835539

The root groups was being treated as an AND group, and thus getting scored even if never considered by GM. Changed this to a 'folder' (OR group with all children needed). I could then get plans created in RT mode.

Looked into GM time accounting and Kristin's suggestion that programs were not getting stopped.
- bad bug found/fixed when using PERCENTAGE for the time buffer  (time * (1 + percent)) instead of (time * percent)
- GM pseudo time accounting was not removing groups when the time was getting used  _update_score now does this.
    We may need to check that all the necessary calibrations are taken, or do this check up front (in the Ranker?)

## Scope

<!-- CI auto-detects this, but it helps reviewers to see at a glance. -->

- [ ] Backend (`backend/`)
- [ ] Frontend (`frontend/`)
- [ ] Docs (`docs/`)
- [ ] CI/Infra (`.github/`)


<!-- 
  REQUIRED: Add a changelog fragment file to this PR.
  
  Quickest way (auto-detects ticket from branch name):
    ./scripts/changelog-fragment "Your change description"
    ./scripts/changelog-fragment "Your change description" fix
    ./scripts/changelog-fragment "" misc

  Manual:
    echo "Description" > changelog.d/GSCHED-190.feature.md

  Types: feature, fix, breaking, deprecation, improvement, doc, misc
  CI will fail if no fragment is found (unless only CI/docs files changed).
-->


## Jira

<!-- JIRA:START -->
<!-- Auto-linked from branch name (e.g. GSCHED-190/description) by the PR Jira Link workflow. -->
<!-- JIRA:END -->

## Checklist

- [ ] Changelog fragment added to `changelog.d/`
- [ ] Commit messages follow conventional commits (`feat(backend):`, `fix(frontend):`, etc.)
- [ ] No breaking changes (or `breaking` fragment added)
