### PR TITLE
Gsched 973/add runner for new observation aggregation

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -92,6 +92,18 @@ jobs:
         run: |
           heroku container:release -a ${{ secrets[matrix.app_secret] }} web
 
+      - name: Run DB migrations
+        if: matrix.mode == 'realtime'
+        run: |
+          APP="${{ secrets[matrix.app_secret] }}"
+          if [ -n "$(heroku config:get DATABASE_URL -a "$APP")" ]; then
+            echo "Running alembic upgrade head on $APP"
+            heroku run --exit-code -a "$APP" \
+              "cd /home && uv run alembic -c alembic.ini upgrade head"
+          else
+            echo "No DATABASE_URL on $APP; skipping migrations."
+          fi
+
   deploy-frontend:
     name: "Deploy Frontend → DEV"
     runs-on: ubuntu-latest

--- a/.github/workflows/promote-prod.yml
+++ b/.github/workflows/promote-prod.yml
@@ -157,6 +157,18 @@ jobs:
         run: |
           heroku container:release -a ${{ secrets[matrix.app_secret] }} web
 
+      - name: Run DB migrations
+        if: matrix.mode == 'realtime'
+        run: |
+          APP="${{ secrets[matrix.app_secret] }}"
+          if [ -n "$(heroku config:get DATABASE_URL -a "$APP")" ]; then
+            echo "Running alembic upgrade head on $APP"
+            heroku run --exit-code -a "$APP" \
+              "cd /home && uv run alembic -c alembic.ini upgrade head"
+          else
+            echo "No DATABASE_URL on $APP; skipping migrations."
+          fi
+
   deploy-frontend:
     name: "Deploy Frontend → PROD"
     runs-on: ubuntu-latest

--- a/backend/alembic/versions/009_add_scheduler_coordination.py
+++ b/backend/alembic/versions/009_add_scheduler_coordination.py
@@ -1,0 +1,35 @@
+"""Add scheduler_coordination table
+
+Revision ID: 009
+Revises: 008
+Create Date: 2026-06-03
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+# Required variables
+revision: str = "009"
+down_revision: Union[str, None] = "008"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "scheduler_coordination",
+        sa.Column("name", sa.String(64), primary_key=True),
+        sa.Column("active", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("holder", sa.String(255), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("heartbeat_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("detail", JSONB(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("scheduler_coordination")

--- a/backend/scheduler.graphql
+++ b/backend/scheduler.graphql
@@ -100,6 +100,7 @@ type Query {
   schedule(scheduleId: String!, newScheduleInput: CreateNewScheduleInput!): String!
   scheduleV2(newScheduleRtInput: CreateNewScheduleRTInput!): String!
   availablePrograms: [AvailableProgram!]!
+  visibilityAggregatorStatus: VisibilityAggregatorStatus!
   buildParameters: BuildParametersResponse!
 }
 
@@ -206,4 +207,14 @@ type TimelineEntriesBySite {
 type Version {
   version: String!
   changelog: [String!]!
+}
+
+type VisibilityAggregatorStatus {
+  active: Boolean!
+  stale: Boolean!
+  holder: String
+  startedAt: String
+  heartbeatAt: String
+  finishedAt: String
+  detail: String
 }

--- a/backend/scheduler/config.yaml
+++ b/backend/scheduler/config.yaml
@@ -31,3 +31,23 @@ sight:
   api_url: http://localhost:9800/api/v1
   # Per-request HTTP timeout in seconds for read-only bulk fetches.
   timeout: 300
+
+# Background visibility-aggregator cron (scheduler.services.visibility_aggregator).
+visibility_aggregator:
+  # How long EngineRT.compute_event_plan blocks while a run is active before
+  # proceeding anyway. null = block until the run finishes (the hard interlock).
+  # Overridable per-deploy via the VIS_AGG_PLAN_WAIT_TIMEOUT env var.
+  plan_wait_timeout: ${oc.decode:${oc.env:VIS_AGG_PLAN_WAIT_TIMEOUT,null}}
+  # A coordination holder whose heartbeat is older than this (seconds) is treated
+  # as dead, so a crashed run never wedges the interlock. This is NOT a run
+  # timeout: a healthy run heartbeats every `heartbeat_interval_seconds` and may
+  # run for as long as it needs (e.g. a ~30 min semester-start backfill). Keep
+  # this comfortably larger than the heartbeat interval (here ~10x).
+  stale_after_seconds: 600
+  # Cadence (seconds) at which a run refreshes its coordination heartbeat.
+  heartbeat_interval_seconds: 60
+  # Cadence (seconds) at which the operation process polls while blocked on a run.
+  idle_poll_interval_seconds: 2
+  # Targets processed per committed Stage-1 batch. Bounds transaction size on
+  # Heroku Postgres and lets a killed run resume from the next batch.
+  target_batch_size: 25

--- a/backend/scheduler/engine/engineRT.py
+++ b/backend/scheduler/engine/engineRT.py
@@ -22,6 +22,7 @@ from scheduler.clients.scheduler_queue_client import SchedulerQueue, SchedulerEv
 from scheduler.events import to_timeslot_idx
 from scheduler.graphql_mid.types import SPlans, NightPlansWithEvent
 from scheduler.night_monitor.event_sources import WeatherEventSource
+from scheduler.services.visibility_aggregator import coordination
 
 from lucupy.minimodel import VariantSnapshot, ImageQuality, CloudCover, Site
 from astropy.coordinates import Angle
@@ -128,8 +129,27 @@ class EngineRT:
 
     async def compute_event_plan(self, event: SchedulerEvent):
         """
+        Compute a new plan for the given event, gated by the aggregator interlock.
+
+        Hard interlock: we never create a plan while the visibility aggregator is
+        running, blocking until it finishes (it only starts when no night is being
+        executed). We then publish that a plan computation is in progress so a
+        cron tick won't begin aggregating concurrently, and clear it when done.
+        """
+        await coordination.wait_until_aggregator_idle()
+        await coordination.signal_plan_in_progress(
+            holder=self.process_id,
+            detail={"event": str(event.trigger_event)},
+        )
+        try:
+            return await self._compute_event_plan(event)
+        finally:
+            await coordination.signal_plan_done()
+
+    async def _compute_event_plan(self, event: SchedulerEvent):
+        """
         Compute a new plan based on the given event.
-        
+
         Args:
             event (Event): The event to compute the plan for.
         Returns:

--- a/backend/scheduler/graphql_mid/schema.py
+++ b/backend/scheduler/graphql_mid/schema.py
@@ -20,9 +20,11 @@ from scheduler.orchestration import process_manager
 from scheduler.services.logger_factory import create_logger
 from scheduler.shared_queue import plan_response_subscribers, build_parameters_subscribers
 from scheduler.clients.gpp import gpp
+from scheduler.services.visibility_aggregator import coordination
 
 from .types import (SPlans, SNightTimelines, NewNightPlans, NightPlansError, Version, SRunSummary,
-                    NewPlansRT, NightPlansResponseRT, NightTimesResponse, BuildParametersInput, BuildParametersResponse, AvailableProgram)
+                    NewPlansRT, NightPlansResponseRT, NightTimesResponse, BuildParametersInput, BuildParametersResponse,
+                    AvailableProgram, VisibilityAggregatorStatus)
 from .inputs import CreateNewScheduleInput, CreateNewScheduleRTInput
 
 from ..core.plans import NightStats
@@ -140,7 +142,12 @@ class Query:
         return [
             AvailableProgram(id=p[1], ref_label=p[0]) for p in results
         ]
-    
+
+    @strawberry.field
+    async def visibility_aggregator_status(self) -> VisibilityAggregatorStatus:
+        status = await coordination.get_aggregator_status()
+        return VisibilityAggregatorStatus(**status)
+
     @strawberry.field
     async def build_parameters(self) -> BuildParametersResponse:
         build_params = await build_params_store.get()

--- a/backend/scheduler/graphql_mid/types.py
+++ b/backend/scheduler/graphql_mid/types.py
@@ -360,3 +360,15 @@ class BuildParametersResponse:
 class AvailableProgram:
     id: str
     ref_label: str
+
+
+@strawberry.type
+class VisibilityAggregatorStatus:
+    """Current state of the background visibility-aggregator cron."""
+    active: bool
+    stale: bool
+    holder: Optional[str]
+    started_at: Optional[str]
+    heartbeat_at: Optional[str]
+    finished_at: Optional[str]
+    detail: Optional[str]  # JSON-encoded progress detail

--- a/backend/scheduler/services/sight/_temporary/lucupy_adapters.py
+++ b/backend/scheduler/services/sight/_temporary/lucupy_adapters.py
@@ -11,6 +11,7 @@ from lucupy.minimodel.timingwindow import TimingWindow
 from scheduler.services.sight.calculator.models import (
     ElevationType as SightElevationType,
     ObservationConstraints as SightObservationConstraints,
+    TargetCreate as SightTargetCreate,
     TimingWindow as SightTimingWindow,
 )
 
@@ -60,6 +61,41 @@ def target_shim(target) -> Optional[SimpleNamespace]:
             pm_ra=None,
             pm_dec=None,
             epoch=2000.0,
+            horizons_id=str(target.des) if target.des is not None else None,
+            tag=target.tag.name.lower() if target.tag is not None else None,
+        )
+    return None
+
+
+def target_create(target) -> Optional[SightTargetCreate]:
+    """Build a sight ``TargetCreate`` payload from a lucupy Target.
+
+    Single home for the lucupy -> sight target mapping, shared by the
+    visibility-aggregator and ``scripts/fill_sight.py``. Returns None for an
+    unrecognised/None target. Non-sidereal targets are mapped too (with
+    placeholder base_ra/base_dec, since the schema requires them); callers that
+    only want sidereal targets check ``.is_sidereal``.
+    """
+    if target is None:
+        return None
+    if isinstance(target, SiderealTarget):
+        return SightTargetCreate(
+            name=str(target.name),
+            is_sidereal=True,
+            base_ra=float(target.ra),
+            base_dec=float(target.dec),
+            pm_ra=float(target.pm_ra) if target.pm_ra is not None else None,
+            pm_dec=float(target.pm_dec) if target.pm_dec is not None else None,
+            epoch=float(target.epoch) if target.epoch is not None else 2000.0,
+        )
+    if isinstance(target, NonsiderealTarget):
+        return SightTargetCreate(
+            name=str(target.name),
+            is_sidereal=False,
+            # Sight requires base_ra/base_dec; non-sidereal targets resolve via
+            # horizons_id, so we send neutral placeholders.
+            base_ra=0.0,
+            base_dec=0.0,
             horizons_id=str(target.des) if target.des is not None else None,
             tag=target.tag.name.lower() if target.tag is not None else None,
         )

--- a/backend/scheduler/services/sight/database/models.py
+++ b/backend/scheduler/services/sight/database/models.py
@@ -285,4 +285,40 @@ class VisibilityData(Base):
 
     def __repr__(self) -> str:
         return f"<VisibilityData obs={self.observation_id} night={self.night_date}>"
+
+
+class SchedulerCoordination(Base):
+    """
+    Cross-process coordination state, shared via Postgres between the always-on
+    operation dyno and the one-off visibility-aggregator cron dyno.
+
+    One row per coordinated activity, keyed by ``name``:
+      - ``visibility_aggregator`` — set active while the aggregator runs so the
+        operation process blocks plan creation until it finishes.
+      - ``night_execution`` — set active while the operation process is computing
+        a plan, so the aggregator does not start work concurrently.
+
+    ``heartbeat_at`` plus a staleness threshold lets a consumer treat a crashed
+    holder's row as inactive instead of wedging the interlock forever.
+    """
+    __tablename__ = "scheduler_coordination"
+
+    name: Mapped[str] = mapped_column(String(64), primary_key=True)
+    active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    holder: Mapped[Optional[str]] = mapped_column(
+        String(255), nullable=True, comment="Dyno / process that owns the row"
+    )
+    started_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    heartbeat_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    finished_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    detail: Mapped[Optional[dict]] = mapped_column(JSONB, nullable=True)
+
+    def __repr__(self) -> str:
+        return f"<SchedulerCoordination {self.name} active={self.active}>"
         

--- a/backend/scheduler/services/visibility_aggregator/README.md
+++ b/backend/scheduler/services/visibility_aggregator/README.md
@@ -1,7 +1,7 @@
 # Visibility aggregator
 
 Background service that keeps the **Sight DB** current for the programs GPP
-reports as *available*. For the current semester it ensures:
+reports as *READY*. For the current semester it ensures:
 
 - **Stage 1** (`target_night_data`) exists for every **sidereal** target, and
 - **Stage 2** (`visibility_data`) exists for every observation,
@@ -21,7 +21,7 @@ It is a one-off process, intended for **Heroku Scheduler**:
 cd /home && uv run python -m scheduler.services.visibility_aggregator.runner
 ```
 
-Heroku Scheduler's minimum interval is 10 minutes; overlapping ticks are
+Heroku Scheduler's minimum interval is 1 hour; overlapping ticks are
 prevented by the coordination row (a second run exits if one is already active).
 Run it locally / manually the same way against a populated `DATABASE_URL`.
 
@@ -32,36 +32,11 @@ inherits all of the app's config vars — there is no separate env config for
 scheduler jobs. The only requirement is that the relevant vars are set on the app
 (the same one running the web/operation dyno):
 
-| Var | Source | Needed because |
-| --- | --- | --- |
-| `DATABASE_URL` | Heroku Postgres add-on (auto) | shared Sight DB + coordination. Must be the same DB as the web dyno. `postgres://` is normalised to `postgresql+asyncpg://` in `sight/config.py`. |
-| GPP credentials (e.g. `GPP_DEVELOPMENT_TOKEN`) | already set for the web dyno | the runner calls GPP. If the web app talks to GPP today, the cron inherits the same credential. |
-| `VIS_AGG_PLAN_WAIT_TIMEOUT` (optional) | you | caps how long plan creation blocks for a run (default: block until finished). |
+The aggregator's own knobs live in `config.yaml` (see **Tuning** below), not in
+env vars — only secrets/connection info come from the environment. `CLOUDCUBE_*`
+/ ephemerides are **not** required either: those are only for non-sidereal
+Horizons targets, which this runner skips for now.
 
-`CLOUDCUBE_*` / ephemerides are **not** required — those are only for
-non-sidereal Horizons targets, which this runner skips for now.
-
-```bash
-# 1. one-time: add the add-on
-heroku addons:create scheduler:standard -a <app>
-
-# 2. confirm the inherited config (DATABASE_URL + GPP creds present)
-heroku config -a <app>
-
-# 3. (optional) safety valve / set any missing var
-heroku config:set VIS_AGG_PLAN_WAIT_TIMEOUT=900 -a <app>
-
-# 4. add the job in the dashboard (command + interval: every 10 min / hourly / daily)
-heroku addons:open scheduler -a <app>
-#    Command:   cd /home && uv run python -m scheduler.services.visibility_aggregator.runner
-#    Dyno size: pick Standard-2X/Performance for the heavy first full-semester backfill.
-
-# 5. smoke-test once on a one-off dyno (also inherits config vars)
-heroku run "cd /home && uv run python -m scheduler.services.visibility_aggregator.runner" -a <app>
-```
-
-The `scheduler_coordination` table is created by the `009` Alembic migration,
-which runs automatically in the existing `heroku.yml` release phase on deploy.
 
 ## Coordination (interlock)
 
@@ -79,18 +54,52 @@ computed astronomically) or a plan is being computed. Liveness is a committed
 `heartbeat_at` plus a staleness threshold, so a crashed holder never wedges the
 interlock.
 
-## Tuning (env vars)
+## Tuning (config.yaml)
 
-- `VIS_AGG_PLAN_WAIT_TIMEOUT` (seconds) — cap how long plan creation blocks for
-  the aggregator. Default: unset = block until finished. Set this as an
-  operational safety valve if a long first-time backfill must not stall a night.
+All knobs live under the `visibility_aggregator` section of
+`scheduler/config.yaml`:
+
+- `plan_wait_timeout` (seconds) — cap how long plan creation blocks for the
+  aggregator. `null` = block until finished. Env-overridable per-deploy via
+  `VIS_AGG_PLAN_WAIT_TIMEOUT` (a safety valve if a long first-time backfill must
+  not stall a night).
+- `stale_after_seconds` — a coordination holder whose heartbeat is older than
+  this is treated as dead (so a crashed run never wedges the interlock).
+- `heartbeat_interval_seconds` — how often a run refreshes its heartbeat.
+- `idle_poll_interval_seconds` — how often the operation process polls while
+  blocked on a run.
+- `target_batch_size` — targets per committed Stage-1 batch.
+
+## Long runs, timeouts, and failures
+
+These three numbers are independent — `stale_after_seconds` is **not** a run
+timeout:
+
+- **`heartbeat_interval_seconds` (60s)** — a live run refreshes `heartbeat_at`
+  this often. The parse phase and each compute batch yield to the event loop, so
+  the heartbeat keeps firing even during a multi-minute backfill.
+- **`stale_after_seconds` (600s)** — how long *readers* wait without a heartbeat
+  before treating the holder as **dead**. It only matters if a run crashes; a
+  healthy run heartbeats 10× within this window and may run as long as it needs
+  (a ~30 min semester-start backfill is fine — the Heroku one-off/Scheduler dyno
+  has no such limit).
+- **`plan_wait_timeout` (null)** — how long the operation process blocks before
+  planning anyway. `null` = block until the run finishes. If a run *crashes*,
+  `stale_after_seconds` is the safety net: planning resumes within 600s instead
+  of blocking forever.
+
+**Resumability.** The work is committed per Stage-1 batch and per Stage-2 night,
+and every write is an idempotent upsert against the "what's already there" diff.
+So if a dyno is killed (cycling, deploy, SIGTERM, dropped connection), nothing is
+half-written: the next cron tick simply fills the remaining gaps. On `SIGTERM`
+the run cancels gracefully and releases the coordination row immediately;
+otherwise the row expires via `stale_after_seconds`.
+
+**Partial data is safe.** The scheduler only ever reads whatever Stage-1/Stage-2
+rows exist and skips the rest (its pre-existing behaviour). An incomplete run
+just means fewer gaps filled this tick, not corrupt or inconsistent data.
 
 ## Observability
 
 `query { visibilityAggregatorStatus { active stale holder heartbeatAt detail } }`
 reports the current run state.
-
-> **First run** is heavy (all sidereal targets × 2 sites × ~6 months). Every
-> later tick is cheap because it only fills gaps. Consider running the first
-> backfill in a daytime window (or manually) so it can't block the start of a
-> night.

--- a/backend/scheduler/services/visibility_aggregator/README.md
+++ b/backend/scheduler/services/visibility_aggregator/README.md
@@ -1,0 +1,96 @@
+# Visibility aggregator
+
+Background service that keeps the **Sight DB** current for the programs GPP
+reports as *available*. For the current semester it ensures:
+
+- **Stage 1** (`target_night_data`) exists for every **sidereal** target, and
+- **Stage 2** (`visibility_data`) exists for every observation,
+
+adding only what is missing. It reuses the existing `Calculator` (the same
+engine `scripts/fill_sight.py` drives), so this package is orchestration + a DB
+diff, not new visibility math.
+
+> **Scope:** sidereal targets only for now. Non-sidereal (Horizons) targets are
+> skipped; see the follow-up note in the code.
+
+## Running it
+
+It is a one-off process, intended for **Heroku Scheduler**:
+
+```
+cd /home && uv run python -m scheduler.services.visibility_aggregator.runner
+```
+
+Heroku Scheduler's minimum interval is 10 minutes; overlapping ticks are
+prevented by the coordination row (a second run exits if one is already active).
+Run it locally / manually the same way against a populated `DATABASE_URL`.
+
+### Heroku setup (env vars)
+
+A Heroku Scheduler job is a **one-off dyno in the same app**, so it automatically
+inherits all of the app's config vars — there is no separate env config for
+scheduler jobs. The only requirement is that the relevant vars are set on the app
+(the same one running the web/operation dyno):
+
+| Var | Source | Needed because |
+| --- | --- | --- |
+| `DATABASE_URL` | Heroku Postgres add-on (auto) | shared Sight DB + coordination. Must be the same DB as the web dyno. `postgres://` is normalised to `postgresql+asyncpg://` in `sight/config.py`. |
+| GPP credentials (e.g. `GPP_DEVELOPMENT_TOKEN`) | already set for the web dyno | the runner calls GPP. If the web app talks to GPP today, the cron inherits the same credential. |
+| `VIS_AGG_PLAN_WAIT_TIMEOUT` (optional) | you | caps how long plan creation blocks for a run (default: block until finished). |
+
+`CLOUDCUBE_*` / ephemerides are **not** required — those are only for
+non-sidereal Horizons targets, which this runner skips for now.
+
+```bash
+# 1. one-time: add the add-on
+heroku addons:create scheduler:standard -a <app>
+
+# 2. confirm the inherited config (DATABASE_URL + GPP creds present)
+heroku config -a <app>
+
+# 3. (optional) safety valve / set any missing var
+heroku config:set VIS_AGG_PLAN_WAIT_TIMEOUT=900 -a <app>
+
+# 4. add the job in the dashboard (command + interval: every 10 min / hourly / daily)
+heroku addons:open scheduler -a <app>
+#    Command:   cd /home && uv run python -m scheduler.services.visibility_aggregator.runner
+#    Dyno size: pick Standard-2X/Performance for the heavy first full-semester backfill.
+
+# 5. smoke-test once on a one-off dyno (also inherits config vars)
+heroku run "cd /home && uv run python -m scheduler.services.visibility_aggregator.runner" -a <app>
+```
+
+The `scheduler_coordination` table is created by the `009` Alembic migration,
+which runs automatically in the existing `heroku.yml` release phase on deploy.
+
+## Coordination (interlock)
+
+Two rows in `scheduler_coordination`, shared with the always-on operation dyno:
+
+- `visibility_aggregator` — set active while a run is in progress. Before
+  creating a plan, `EngineRT.compute_event_plan` calls
+  `coordination.wait_until_aggregator_idle()` and **blocks until the run
+  finishes** (the hard interlock).
+- `night_execution` — set active while the operation process is computing a
+  plan, so a cron tick won't start concurrently.
+
+A run is **skipped** when a night is in progress (12° dark time at GN or GS,
+computed astronomically) or a plan is being computed. Liveness is a committed
+`heartbeat_at` plus a staleness threshold, so a crashed holder never wedges the
+interlock.
+
+## Tuning (env vars)
+
+- `VIS_AGG_PLAN_WAIT_TIMEOUT` (seconds) — cap how long plan creation blocks for
+  the aggregator. Default: unset = block until finished. Set this as an
+  operational safety valve if a long first-time backfill must not stall a night.
+
+## Observability
+
+`query { visibilityAggregatorStatus { active stale holder heartbeatAt detail } }`
+reports the current run state.
+
+> **First run** is heavy (all sidereal targets × 2 sites × ~6 months). Every
+> later tick is cheap because it only fills gaps. Consider running the first
+> backfill in a daytime window (or manually) so it can't block the start of a
+> night.

--- a/backend/scheduler/services/visibility_aggregator/__init__.py
+++ b/backend/scheduler/services/visibility_aggregator/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2016-2026 Association of Universities for Research in Astronomy, Inc. (AURA)
+# For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+"""Background visibility-aggregator: keeps the Sight DB's Stage 1 (targets) and
+Stage 2 (observations) current for the available GPP programs.
+
+Run as a Heroku Scheduler one-off dyno:
+    python -m scheduler.services.visibility_aggregator.runner
+"""

--- a/backend/scheduler/services/visibility_aggregator/aggregator.py
+++ b/backend/scheduler/services/visibility_aggregator/aggregator.py
@@ -1,0 +1,258 @@
+# Copyright (c) 2016-2026 Association of Universities for Research in Astronomy, Inc. (AURA)
+# For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+from datetime import date, datetime, timedelta, timezone
+from typing import Awaitable, Callable, Optional
+
+import numpy as np
+from astropy.time import Time
+from lucupy import sky
+from lucupy.minimodel import ALL_SITES, ObservationClass
+from lucupy.minimodel.semester import Semester
+from lucupy.types import ZeroTime
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from scheduler.clients.gpp import gpp
+from scheduler.core.programprovider.gpp import GppProgramProvider, gpp_program_data
+from scheduler.core.sources.sources import Sources
+from scheduler.services import logger_factory
+from scheduler.services.sight._temporary.lucupy_adapters import (
+    stage2_constraints,
+    target_create,
+)
+from scheduler.services.sight.calculator.calculator import Calculator
+from scheduler.services.sight.calculator.models import ObservationRequest
+
+_logger = logger_factory.create_logger(__name__)
+
+__all__ = ["run_aggregation", "is_night_in_progress"]
+
+# Heartbeat callback: an async fn the runner passes so it can refresh its
+# coordination row (and surface progress) between chunks of work.
+Heartbeat = Callable[[dict], Awaitable[None]]
+
+_OBS_CLASSES = frozenset({
+    ObservationClass.SCIENCE,
+    ObservationClass.PROGCAL,
+    ObservationClass.PARTNERCAL,
+})
+
+
+def _as_utc_datetime(t: Time) -> datetime:
+    """Astropy Time to a UTC datetime."""
+    return np.atleast_1d(t.to_datetime(timezone=timezone.utc))[0]
+
+
+def is_night_in_progress(now: Optional[datetime] = None) -> bool:
+    """True if it is currently dark time (12 deg twilight) at GN or GS.
+
+    We check both the night anchored to ``now`` and to ``now - 1 day`` so a night whose twilights
+    are dated to the previous calendar day is still detected.
+    """
+    now = now or datetime.now(timezone.utc)
+    for site in ALL_SITES:
+        for day_offset in (0, -1):
+            try:
+                events = sky.night_events(
+                    Time(now + timedelta(days=day_offset)),
+                    site.location,
+                    site.timezone,
+                )
+                eve_twi = _as_utc_datetime(events[3])
+                morn_twi = _as_utc_datetime(events[4])
+            except Exception as exc:
+                _logger.warning(f"night_events failed for {site.name}: {exc}")
+                continue
+            if eve_twi <= now <= morn_twi:
+                _logger.info(
+                    f"Dark time in progress at {site.name} "
+                    f"({eve_twi.isoformat()} .. {morn_twi.isoformat()})."
+                )
+                return True
+    return False
+
+
+async def _collect_requests(program_ids: list[str], range_end: datetime):
+    """Parse the available GPP programs into sidereal targets + obs requests."""
+    provider = GppProgramProvider(_OBS_CLASSES, Sources())
+
+    targets_by_name: dict = {}
+    requests: list[ObservationRequest] = []
+    skipped_no_target = 0
+    skipped_nonsidereal = 0
+    bad_programs = 0
+
+    program_data = await gpp_program_data(program_ids)
+    async for raw in program_data:
+        try:
+            data = next(iter(raw.values())) if len(raw.keys()) == 1 else raw
+            program = provider.parse_program(data)
+            if program is None:
+                continue
+            if program.program_awarded() == ZeroTime:
+                continue
+
+            for obs in program.observations():
+                base = obs.base_target()
+                # We are skipping no target observations as they should not be ready
+                if base is None:
+                    skipped_no_target += 1
+                    continue
+                payload = target_create(base)
+                if payload is None:
+                    skipped_no_target += 1
+                    continue
+                # TODO: Add NonSideral support
+                if not payload.is_sidereal:
+                    skipped_nonsidereal += 1
+                    continue
+
+                targets_by_name.setdefault(payload.name, payload)
+                requests.append(ObservationRequest(
+                    observation_id=obs.id.id,
+                    target_name=str(base.name),
+                    site_id=obs.site.name,
+                    constraints=stage2_constraints(
+                        obs,
+                        has_resources=True,
+                        can_schedule=True,
+                        range_end=range_end,
+                    ),
+                ))
+        except Exception as exc:
+            bad_programs += 1
+            _logger.warning(f"Failed to process a program: {exc}")
+
+    if bad_programs:
+        _logger.info(f"Skipped {bad_programs} unparseable programs.")
+    counts = {
+        "skipped_no_target": skipped_no_target,
+        "skipped_nonsidereal": skipped_nonsidereal,
+    }
+    return targets_by_name, requests, counts
+
+
+async def _store_missing_visibility(
+    calc: Calculator,
+    requests: list[ObservationRequest],
+    start_date: date,
+    end_date: date,
+    heartbeat: Optional[Heartbeat],
+) -> int:
+    """Store Stage 2 only for (observation, night) pairs not already present.
+
+    This is the "add only the ones not there" step: without it,
+    ``store_visibility`` would recompute the whole semester on every cron tick.
+    Commits per night to bound transaction size and persist progress.
+    """
+    if not requests:
+        return 0
+
+    obs_ids = [r.observation_id for r in requests]
+    stored = 0
+    current = start_date
+    while current <= end_date:
+        existing = await calc.visibility_repo.get_by_observation_ids_on_night(
+            obs_ids, current
+        )
+        existing_ids = {d.observation_id for d in existing}
+        missing = [r for r in requests if r.observation_id not in existing_ids]
+
+        if missing:
+            result = await calc.store_visibility(missing, current, current)
+            stored += int(result.get("stored", 0))
+            await calc.session.commit()
+
+        if heartbeat is not None:
+            await heartbeat({
+                "phase": "stage2",
+                "night": current.isoformat(),
+                "stored": stored,
+            })
+        current += timedelta(days=1)
+
+    return stored
+
+
+async def run_aggregation(
+    session: AsyncSession,
+    *,
+    heartbeat: Optional[Heartbeat] = None,
+) -> dict:
+    """Bring the Sight DB up to date for the current semester (sidereal only).
+
+    session (AsyncSession): is the compute session (its own connection).
+    heartbeat (Optional[Heartbeat]): is an optional async callback used to keep the coordination row fresh.
+    """
+    today = datetime.now(timezone.utc).date()
+    semester = Semester.find_semester_from_date(today)
+    start_date = semester.start_date()
+    end_date = semester.end_date()
+    range_end = datetime.combine(end_date, datetime.min.time(), tzinfo=timezone.utc)
+
+    labels = await gpp.client.scheduler.get_all_reference_labels()
+    program_ids = [label[1] for label in labels]
+    _logger.info(
+        f"{len(program_ids)} available programs; semester {semester} "
+        f"({start_date} .. {end_date})."
+    )
+
+    targets_by_name, requests, counts = await _collect_requests(
+        program_ids, range_end
+    )
+    _logger.info(
+        f"Prepared {len(targets_by_name)} sidereal targets and {len(requests)} "
+        f"observations (skipped {counts['skipped_nonsidereal']} non-sidereal, "
+        f"{counts['skipped_no_target']} without a usable base target)."
+    )
+    if heartbeat is not None:
+        await heartbeat({
+            "phase": "parsed",
+            "programs": len(program_ids),
+            "targets": len(targets_by_name),
+            "observations": len(requests),
+        })
+
+    calc = Calculator(session)
+    targets = list(targets_by_name.values())
+
+    # Stage 1: create new targets (sight skips ones that already exist) and
+    # pre-compute their position arrays for the range.
+    created = await calc.create_targets_bulk(targets, start_date, end_date)
+    await session.commit()
+    _logger.info(
+        f"Stage 1 targets: created={created.created} skipped/failed={created.failed}."
+    )
+    if heartbeat is not None:
+        await heartbeat({"phase": "stage1_targets", "created": created.created})
+
+    # Stage 1: ensure position arrays exist for every night in the range, also
+    # filling gaps for targets that already existed (e.g. new semester nights).
+    precompute = await calc.precompute_stage1(
+        start_date, end_date, target_names=list(targets_by_name.keys())
+    )
+    await session.commit()
+    _logger.info(
+        f"Stage 1 precompute: nights={precompute.get('nights')} "
+        f"computations={precompute.get('total_computations')}."
+    )
+    if heartbeat is not None:
+        await heartbeat({"phase": "stage1_precompute", **precompute})
+
+    # Stage 2: store visibility for observations missing it on each night.
+    stored = await _store_missing_visibility(
+        calc, requests, start_date, end_date, heartbeat
+    )
+    _logger.info(f"Stage 2: stored {stored} new visibility rows.")
+
+    return {
+        "semester": str(semester),
+        "start_date": start_date.isoformat(),
+        "end_date": end_date.isoformat(),
+        "programs": len(program_ids),
+        "targets": len(targets),
+        "targets_created": created.created,
+        "observations": len(requests),
+        "stage2_stored": stored,
+        **counts,
+    }

--- a/backend/scheduler/services/visibility_aggregator/aggregator.py
+++ b/backend/scheduler/services/visibility_aggregator/aggregator.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2016-2026 Association of Universities for Research in Astronomy, Inc. (AURA)
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
+import asyncio
+import time
 from datetime import date, datetime, timedelta, timezone
 from typing import Awaitable, Callable, Optional
 
@@ -12,6 +14,7 @@ from lucupy.minimodel.semester import Semester
 from lucupy.types import ZeroTime
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from scheduler.config import config
 from scheduler.clients.gpp import gpp
 from scheduler.core.programprovider.gpp import GppProgramProvider, gpp_program_data
 from scheduler.core.sources.sources import Sources
@@ -41,6 +44,15 @@ _OBS_CLASSES = frozenset({
 def _as_utc_datetime(t: Time) -> datetime:
     """Astropy Time to a UTC datetime."""
     return np.atleast_1d(t.to_datetime(timezone=timezone.utc))[0]
+
+
+def _format_duration(seconds: float) -> str:
+    """Human-readable duration for ETA logging."""
+    if seconds < 90:
+        return f"{seconds:.0f}s"
+    if seconds < 5400:
+        return f"{seconds / 60:.1f}m"
+    return f"{seconds / 3600:.1f}h"
 
 
 def is_night_in_progress(now: Optional[datetime] = None) -> bool:
@@ -83,7 +95,15 @@ async def _collect_requests(program_ids: list[str], range_end: datetime):
     bad_programs = 0
 
     program_data = await gpp_program_data(program_ids)
+    processed = 0
     async for raw in program_data:
+        processed += 1
+        # Parsing is CPU-bound and the async-generator body has no awaits, so a
+        # large semester-start dump would otherwise block the event loop (and
+        # starve the runner's heartbeat task). Yield periodically so heartbeats
+        # keep firing and the coordination row stays fresh.
+        if processed % 25 == 0:
+            await asyncio.sleep(0)
         try:
             data = next(iter(raw.values())) if len(raw.keys()) == 1 else raw
             program = provider.parse_program(data)
@@ -149,6 +169,8 @@ async def _store_missing_visibility(
         return 0
 
     obs_ids = [r.observation_id for r in requests]
+    total_nights = (end_date - start_date).days + 1
+    loop_t0 = time.perf_counter()
     stored = 0
     current = start_date
     while current <= end_date:
@@ -159,9 +181,24 @@ async def _store_missing_visibility(
         missing = [r for r in requests if r.observation_id not in existing_ids]
 
         if missing:
+            t0 = time.perf_counter()
             result = await calc.store_visibility(missing, current, current)
-            stored += int(result.get("stored", 0))
             await calc.session.commit()
+            elapsed = time.perf_counter() - t0
+            night_stored = int(result.get("stored", 0))
+            stored += night_stored
+
+            # Moving ETA: measured seconds/night so far x nights remaining.
+            nights_done = (current - start_date).days + 1
+            eta = (time.perf_counter() - loop_t0) / nights_done * (
+                total_nights - nights_done
+            )
+            _logger.info(
+                f"Stage 2 {current.isoformat()} [{nights_done}/{total_nights}]: "
+                f"{len(missing)} missing obs, stored {night_stored} in {elapsed:.1f}s "
+                f"({elapsed / len(missing) * 1000:.0f} ms/obs); "
+                f"ETA ~{_format_duration(eta)}."
+            )
 
         if heartbeat is not None:
             await heartbeat({
@@ -184,6 +221,7 @@ async def run_aggregation(
     session (AsyncSession): is the compute session (its own connection).
     heartbeat (Optional[Heartbeat]): is an optional async callback used to keep the coordination row fresh.
     """
+    run_t0 = time.perf_counter()
     today = datetime.now(timezone.utc).date()
     semester = Semester.find_semester_from_date(today)
     start_date = semester.start_date()
@@ -197,12 +235,15 @@ async def run_aggregation(
         f"({start_date} .. {end_date})."
     )
 
+    parse_t0 = time.perf_counter()
     targets_by_name, requests, counts = await _collect_requests(
         program_ids, range_end
     )
+    parse_elapsed = time.perf_counter() - parse_t0
     _logger.info(
         f"Prepared {len(targets_by_name)} sidereal targets and {len(requests)} "
-        f"observations (skipped {counts['skipped_nonsidereal']} non-sidereal, "
+        f"observations in {parse_elapsed:.1f}s (skipped "
+        f"{counts['skipped_nonsidereal']} non-sidereal, "
         f"{counts['skipped_no_target']} without a usable base target)."
     )
     if heartbeat is not None:
@@ -215,35 +256,63 @@ async def run_aggregation(
 
     calc = Calculator(session)
     targets = list(targets_by_name.values())
+    batch_size = max(1, int(config.visibility_aggregator.target_batch_size))
 
-    # Stage 1: create new targets (sight skips ones that already exist) and
-    # pre-compute their position arrays for the range.
-    created = await calc.create_targets_bulk(targets, start_date, end_date)
-    await session.commit()
+    # Stage 1, in batches: create new targets (sight skips existing ones) and
+    # ensure position arrays exist for every night in the range — including
+    # gaps for targets that already existed (e.g. new semester nights).
+    #
+    # We commit per batch so a long semester-start backfill never holds one
+    # giant transaction, and so progress persists.
+    # A dyno killed mid-run just resumes from the remaining gaps on the next cron tick (every upsert is idempotent).
+    created_total = 0
+    stage1_t0 = time.perf_counter()
+    for offset in range(0, len(targets), batch_size):
+        chunk = targets[offset:offset + batch_size]
+        batch_t0 = time.perf_counter()
+        created = await calc.create_targets_bulk(chunk, start_date, end_date)
+        created_total += created.created
+        await calc.precompute_stage1(
+            start_date, end_date, target_names=[t.name for t in chunk]
+        )
+        await session.commit()
+        batch_elapsed = time.perf_counter() - batch_t0
+        done = min(offset + batch_size, len(targets))
+        _logger.info(
+            f"Stage 1 batch {offset // batch_size + 1}: {len(chunk)} targets in "
+            f"{batch_elapsed:.1f}s ({batch_elapsed / len(chunk):.2f}s/target); "
+            f"{done}/{len(targets)} done."
+        )
+        if heartbeat is not None:
+            await heartbeat({
+                "phase": "stage1",
+                "targets_done": done,
+                "targets_total": len(targets),
+                "created": created_total,
+            })
+    stage1_elapsed = time.perf_counter() - stage1_t0
+    avg_target = stage1_elapsed / len(targets) if targets else 0.0
     _logger.info(
-        f"Stage 1 targets: created={created.created} skipped/failed={created.failed}."
+        f"Stage 1 done: {created_total} new targets; {len(targets)} targets "
+        f"ensured over {start_date}..{end_date} in {stage1_elapsed:.1f}s "
+        f"({avg_target:.2f}s/target avg)."
     )
-    if heartbeat is not None:
-        await heartbeat({"phase": "stage1_targets", "created": created.created})
-
-    # Stage 1: ensure position arrays exist for every night in the range, also
-    # filling gaps for targets that already existed (e.g. new semester nights).
-    precompute = await calc.precompute_stage1(
-        start_date, end_date, target_names=list(targets_by_name.keys())
-    )
-    await session.commit()
-    _logger.info(
-        f"Stage 1 precompute: nights={precompute.get('nights')} "
-        f"computations={precompute.get('total_computations')}."
-    )
-    if heartbeat is not None:
-        await heartbeat({"phase": "stage1_precompute", **precompute})
 
     # Stage 2: store visibility for observations missing it on each night.
+    stage2_t0 = time.perf_counter()
     stored = await _store_missing_visibility(
         calc, requests, start_date, end_date, heartbeat
     )
-    _logger.info(f"Stage 2: stored {stored} new visibility rows.")
+    stage2_elapsed = time.perf_counter() - stage2_t0
+    _logger.info(f"Stage 2: stored {stored} new visibility rows in {stage2_elapsed:.1f}s.")
+
+    total_elapsed = time.perf_counter() - run_t0
+    _logger.info(
+        f"Aggregation timing: total={total_elapsed:.1f}s "
+        f"(parse={parse_elapsed:.1f}s, stage1={stage1_elapsed:.1f}s, "
+        f"stage2={stage2_elapsed:.1f}s); {len(targets)} targets, "
+        f"{stored} stage-2 rows inserted."
+    )
 
     return {
         "semester": str(semester),
@@ -251,8 +320,12 @@ async def run_aggregation(
         "end_date": end_date.isoformat(),
         "programs": len(program_ids),
         "targets": len(targets),
-        "targets_created": created.created,
+        "targets_created": created_total,
         "observations": len(requests),
         "stage2_stored": stored,
+        "elapsed_seconds": round(total_elapsed, 1),
+        "parse_seconds": round(parse_elapsed, 1),
+        "stage1_seconds": round(stage1_elapsed, 1),
+        "stage2_seconds": round(stage2_elapsed, 1),
         **counts,
     }

--- a/backend/scheduler/services/visibility_aggregator/coordination.py
+++ b/backend/scheduler/services/visibility_aggregator/coordination.py
@@ -19,12 +19,12 @@ Two rows:
 
 import asyncio
 import json
-import os
 from typing import Optional
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from scheduler.config import config
 from scheduler.services.logger_factory import create_logger
 from scheduler.services.sight.database.connection import session_scope
 
@@ -48,14 +48,23 @@ __all__ = [
 AGGREGATOR_NAME = "visibility_aggregator"
 NIGHT_EXECUTION_NAME = "night_execution"
 
+# Tunables live in config.yaml under the `visibility_aggregator` section.
+_agg_config = config.visibility_aggregator
+
 # A holder whose heartbeat is older than this is treated as dead.
-STALE_AFTER_SECONDS = 300.0
+STALE_AFTER_SECONDS: float = float(_agg_config.stale_after_seconds)
+
+# Cadence the operation process polls at while blocked on a run.
+_IDLE_POLL_INTERVAL_SECONDS: float = float(_agg_config.idle_poll_interval_seconds)
 
 
 # --- low-level helpers (caller owns the transaction / commit) ----------------
 
-async def _acquire(session: AsyncSession, name: str, holder: str,
-                   stale_after: float) -> bool:
+async def _acquire(
+    session: AsyncSession,
+    name: str, holder: str,
+    stale_after: float
+) -> bool:
     """Atomically take ``name`` if it is inactive or its holder is stale.
 
     Returns True iff this caller now owns the row. Caller must commit.
@@ -113,7 +122,7 @@ async def _release(session: AsyncSession, name: str) -> None:
 
 async def _is_active(session: AsyncSession, name: str,
                      stale_after: float) -> bool:
-    """True iff ``name`` is active and its heartbeat is fresh."""
+    """True if ``name`` is active and its heartbeat is fresh."""
     stmt = text(
         """
         SELECT 1 FROM scheduler_coordination
@@ -126,7 +135,6 @@ async def _is_active(session: AsyncSession, name: str,
     return result.first() is not None
 
 
-# --- aggregator side (used by the cron runner, owns its session) -------------
 
 async def acquire_aggregator(session: AsyncSession, holder: str,
                              stale_after: float = STALE_AFTER_SECONDS) -> bool:
@@ -147,8 +155,6 @@ async def is_plan_in_progress(session: AsyncSession,
     return await _is_active(session, NIGHT_EXECUTION_NAME, stale_after)
 
 
-# --- operation side (used by EngineRT; manage their own short sessions) ------
-
 async def is_aggregator_active(session: AsyncSession,
                                stale_after: float = STALE_AFTER_SECONDS) -> bool:
     return await _is_active(session, AGGREGATOR_NAME, stale_after)
@@ -157,15 +163,15 @@ async def is_aggregator_active(session: AsyncSession,
 def _plan_wait_timeout() -> Optional[float]:
     """Cap on how long plan creation blocks for the aggregator.
 
-    Defaults to None ("block until finished", per the agreed hard interlock).
-    Set ``VIS_AGG_PLAN_WAIT_TIMEOUT`` (seconds) to cap it as an operational
-    safety valve.
+    Configured by ``visibility_aggregator.plan_wait_timeout`` in config.yaml;
+    None means "block until finished" (the agreed hard interlock). That key is
+    env-overridable per-deploy via ``VIS_AGG_PLAN_WAIT_TIMEOUT``.
     """
-    raw = os.environ.get("VIS_AGG_PLAN_WAIT_TIMEOUT")
-    return float(raw) if raw else None
+    value = config.visibility_aggregator.plan_wait_timeout
+    return float(value) if value is not None else None
 
 
-async def wait_until_aggregator_idle(poll_interval: float = 2.0,
+async def wait_until_aggregator_idle(poll_interval: float = _IDLE_POLL_INTERVAL_SECONDS,
                                      timeout: Optional[float] = None) -> bool:
     """Block until the aggregator row is inactive/stale (the hard interlock).
 
@@ -188,8 +194,15 @@ async def wait_until_aggregator_idle(poll_interval: float = 2.0,
                             f"proceeding with plan creation."
                         )
                     return True
-        except RuntimeError:
-            # DATABASE_URL not configured — nothing to coordinate with.
+        except Exception as exc:
+            # Fail open: a missing DATABASE_URL, a coordination table that hasn't
+            # been migrated yet (deploy window), or a transient DB error must
+            # never block plan creation. (CancelledError is a BaseException and
+            # is intentionally not caught here.)
+            _logger.warning(
+                f"Coordination check unavailable ({exc}); proceeding with plan "
+                f"creation without the aggregator interlock."
+            )
             return True
         if timeout is not None and waited >= timeout:
             _logger.warning(
@@ -214,8 +227,10 @@ async def signal_plan_in_progress(holder: str = "operation",
             await _acquire_unconditional(session, NIGHT_EXECUTION_NAME, holder)
             if detail is not None:
                 await _heartbeat(session, NIGHT_EXECUTION_NAME, detail)
-    except RuntimeError:
-        pass  # No DB configured; nothing to signal.
+    except Exception as exc:
+        # Best-effort signal; never let it interfere with planning (no DB,
+        # un-migrated table, or transient error).
+        _logger.debug(f"Could not signal plan-in-progress: {exc}")
 
 
 async def signal_plan_done() -> None:
@@ -223,8 +238,8 @@ async def signal_plan_done() -> None:
     try:
         async with session_scope() as session:
             await _release(session, NIGHT_EXECUTION_NAME)
-    except RuntimeError:
-        pass
+    except Exception as exc:
+        _logger.debug(f"Could not clear plan-in-progress: {exc}")
 
 
 async def get_aggregator_status() -> dict:
@@ -251,7 +266,10 @@ async def get_aggregator_status() -> dict:
             row = (await session.execute(
                 stmt, {"name": AGGREGATOR_NAME, "stale": STALE_AFTER_SECONDS}
             )).mappings().first()
-    except RuntimeError:
+    except Exception as exc:
+        # No DB / un-migrated table / transient error: report "not running"
+        # rather than failing the GraphQL query.
+        _logger.debug(f"Could not read aggregator status: {exc}")
         return empty
     if row is None:
         return empty

--- a/backend/scheduler/services/visibility_aggregator/coordination.py
+++ b/backend/scheduler/services/visibility_aggregator/coordination.py
@@ -1,0 +1,286 @@
+# Copyright (c) 2016-2026 Association of Universities for Research in Astronomy, Inc. (AURA)
+# For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+"""Cross-process coordination between the operation dyno and the aggregator cron.
+
+State lives in the ``scheduler_coordination`` Postgres table (one row per
+activity) so it is visible across separate dynos. We deliberately avoid Postgres
+advisory locks: a session-level lock would need a pinned connection held across
+commits, which fights SQLAlchemy's connection-per-transaction pooling. Instead,
+acquisition is an *atomic conditional upsert* (``INSERT ... ON CONFLICT DO UPDATE
+... WHERE not active or stale``) and liveness is a committed ``heartbeat_at`` plus
+a staleness threshold, so a crashed holder never wedges the interlock.
+
+Two rows:
+  - ``visibility_aggregator`` — active while the aggregator runs; the operation
+    process waits on it before creating a plan.
+  - ``night_execution`` — active while the operation process computes a plan; the
+    aggregator skips a cycle if it is set (and fresh).
+"""
+
+import asyncio
+import json
+import os
+from typing import Optional
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from scheduler.services.logger_factory import create_logger
+from scheduler.services.sight.database.connection import session_scope
+
+_logger = create_logger(__name__, with_id=False)
+
+__all__ = [
+    "AGGREGATOR_NAME",
+    "NIGHT_EXECUTION_NAME",
+    "STALE_AFTER_SECONDS",
+    "acquire_aggregator",
+    "heartbeat_aggregator",
+    "release_aggregator",
+    "is_aggregator_active",
+    "wait_until_aggregator_idle",
+    "signal_plan_in_progress",
+    "signal_plan_done",
+    "is_plan_in_progress",
+    "get_aggregator_status",
+]
+
+AGGREGATOR_NAME = "visibility_aggregator"
+NIGHT_EXECUTION_NAME = "night_execution"
+
+# A holder whose heartbeat is older than this is treated as dead.
+STALE_AFTER_SECONDS = 300.0
+
+
+# --- low-level helpers (caller owns the transaction / commit) ----------------
+
+async def _acquire(session: AsyncSession, name: str, holder: str,
+                   stale_after: float) -> bool:
+    """Atomically take ``name`` if it is inactive or its holder is stale.
+
+    Returns True iff this caller now owns the row. Caller must commit.
+    """
+    stmt = text(
+        """
+        INSERT INTO scheduler_coordination
+            (name, active, holder, started_at, heartbeat_at, finished_at)
+        VALUES (:name, true, :holder, now(), now(), null)
+        ON CONFLICT (name) DO UPDATE
+            SET active = true,
+                holder = :holder,
+                started_at = now(),
+                heartbeat_at = now(),
+                finished_at = null
+            WHERE scheduler_coordination.active = false
+               OR scheduler_coordination.heartbeat_at
+                  < now() - make_interval(secs => :stale)
+        RETURNING name
+        """
+    )
+    result = await session.execute(
+        stmt, {"name": name, "holder": holder, "stale": stale_after}
+    )
+    return result.first() is not None
+
+
+async def _heartbeat(session: AsyncSession, name: str,
+                     detail: Optional[dict]) -> None:
+    """Refresh ``heartbeat_at`` (and optionally ``detail``). Caller commits."""
+    if detail is None:
+        stmt = text(
+            "UPDATE scheduler_coordination SET heartbeat_at = now() "
+            "WHERE name = :name"
+        )
+        await session.execute(stmt, {"name": name})
+    else:
+        stmt = text(
+            "UPDATE scheduler_coordination "
+            "SET heartbeat_at = now(), detail = cast(:detail as jsonb) "
+            "WHERE name = :name"
+        )
+        await session.execute(stmt, {"name": name, "detail": json.dumps(detail)})
+
+
+async def _release(session: AsyncSession, name: str) -> None:
+    """Mark ``name`` inactive. Caller commits."""
+    stmt = text(
+        "UPDATE scheduler_coordination "
+        "SET active = false, finished_at = now(), heartbeat_at = now() "
+        "WHERE name = :name"
+    )
+    await session.execute(stmt, {"name": name})
+
+
+async def _is_active(session: AsyncSession, name: str,
+                     stale_after: float) -> bool:
+    """True iff ``name`` is active and its heartbeat is fresh."""
+    stmt = text(
+        """
+        SELECT 1 FROM scheduler_coordination
+        WHERE name = :name
+          AND active = true
+          AND heartbeat_at > now() - make_interval(secs => :stale)
+        """
+    )
+    result = await session.execute(stmt, {"name": name, "stale": stale_after})
+    return result.first() is not None
+
+
+# --- aggregator side (used by the cron runner, owns its session) -------------
+
+async def acquire_aggregator(session: AsyncSession, holder: str,
+                             stale_after: float = STALE_AFTER_SECONDS) -> bool:
+    return await _acquire(session, AGGREGATOR_NAME, holder, stale_after)
+
+
+async def heartbeat_aggregator(session: AsyncSession,
+                               detail: Optional[dict] = None) -> None:
+    await _heartbeat(session, AGGREGATOR_NAME, detail)
+
+
+async def release_aggregator(session: AsyncSession) -> None:
+    await _release(session, AGGREGATOR_NAME)
+
+
+async def is_plan_in_progress(session: AsyncSession,
+                              stale_after: float = STALE_AFTER_SECONDS) -> bool:
+    return await _is_active(session, NIGHT_EXECUTION_NAME, stale_after)
+
+
+# --- operation side (used by EngineRT; manage their own short sessions) ------
+
+async def is_aggregator_active(session: AsyncSession,
+                               stale_after: float = STALE_AFTER_SECONDS) -> bool:
+    return await _is_active(session, AGGREGATOR_NAME, stale_after)
+
+
+def _plan_wait_timeout() -> Optional[float]:
+    """Cap on how long plan creation blocks for the aggregator.
+
+    Defaults to None ("block until finished", per the agreed hard interlock).
+    Set ``VIS_AGG_PLAN_WAIT_TIMEOUT`` (seconds) to cap it as an operational
+    safety valve.
+    """
+    raw = os.environ.get("VIS_AGG_PLAN_WAIT_TIMEOUT")
+    return float(raw) if raw else None
+
+
+async def wait_until_aggregator_idle(poll_interval: float = 2.0,
+                                     timeout: Optional[float] = None) -> bool:
+    """Block until the aggregator row is inactive/stale (the hard interlock).
+
+    Each poll uses its own short session so it sees the aggregator's committed
+    heartbeats. Returns True when idle, False if ``timeout`` elapses first. The
+    default (block until finished) honours the agreed interlock; pass a timeout
+    or set ``VIS_AGG_PLAN_WAIT_TIMEOUT`` to cap the wait. A missing DATABASE_URL
+    is treated as "no aggregator" so local/in-memory runs are unaffected.
+    """
+    if timeout is None:
+        timeout = _plan_wait_timeout()
+    waited = 0.0
+    while True:
+        try:
+            async with session_scope() as session:
+                if not await is_aggregator_active(session):
+                    if waited:
+                        _logger.info(
+                            f"Aggregator finished after waiting {waited:.0f}s; "
+                            f"proceeding with plan creation."
+                        )
+                    return True
+        except RuntimeError:
+            # DATABASE_URL not configured — nothing to coordinate with.
+            return True
+        if timeout is not None and waited >= timeout:
+            _logger.warning(
+                f"Timed out after {waited:.0f}s waiting for the visibility "
+                f"aggregator to finish; proceeding with plan creation."
+            )
+            return False
+        if waited == 0.0:
+            _logger.info(
+                "Visibility aggregator is running; deferring plan creation "
+                "until it finishes."
+            )
+        await asyncio.sleep(poll_interval)
+        waited += poll_interval
+
+
+async def signal_plan_in_progress(holder: str = "operation",
+                                  detail: Optional[dict] = None) -> None:
+    """Mark that the operation process is computing a plan (best-effort)."""
+    try:
+        async with session_scope() as session:
+            await _acquire_unconditional(session, NIGHT_EXECUTION_NAME, holder)
+            if detail is not None:
+                await _heartbeat(session, NIGHT_EXECUTION_NAME, detail)
+    except RuntimeError:
+        pass  # No DB configured; nothing to signal.
+
+
+async def signal_plan_done() -> None:
+    """Clear the plan-in-progress flag (best-effort)."""
+    try:
+        async with session_scope() as session:
+            await _release(session, NIGHT_EXECUTION_NAME)
+    except RuntimeError:
+        pass
+
+
+async def get_aggregator_status() -> dict:
+    """Snapshot the aggregator coordination row for display (UI / debugging).
+
+    Timestamps are returned as ISO strings; ``stale`` is True when the row is
+    marked active but its heartbeat has expired. Safe when DATABASE_URL is unset.
+    """
+    empty = {
+        "active": False, "holder": None, "started_at": None,
+        "heartbeat_at": None, "finished_at": None, "stale": False, "detail": None,
+    }
+    try:
+        async with session_scope() as session:
+            stmt = text(
+                """
+                SELECT active, holder, started_at, heartbeat_at, finished_at, detail,
+                       (active AND heartbeat_at
+                            > now() - make_interval(secs => :stale)) AS fresh
+                FROM scheduler_coordination
+                WHERE name = :name
+                """
+            )
+            row = (await session.execute(
+                stmt, {"name": AGGREGATOR_NAME, "stale": STALE_AFTER_SECONDS}
+            )).mappings().first()
+    except RuntimeError:
+        return empty
+    if row is None:
+        return empty
+
+    def _iso(value):
+        return value.isoformat() if value is not None else None
+
+    return {
+        "active": bool(row["active"]),
+        "holder": row["holder"],
+        "started_at": _iso(row["started_at"]),
+        "heartbeat_at": _iso(row["heartbeat_at"]),
+        "finished_at": _iso(row["finished_at"]),
+        "stale": bool(row["active"]) and not bool(row["fresh"]),
+        "detail": json.dumps(row["detail"]) if row["detail"] is not None else None,
+    }
+
+
+async def _acquire_unconditional(session: AsyncSession, name: str,
+                                 holder: str) -> None:
+    """Set ``name`` active unconditionally (single writer, no contention)."""
+    stmt = text(
+        """
+        INSERT INTO scheduler_coordination
+            (name, active, holder, started_at, heartbeat_at, finished_at)
+        VALUES (:name, true, :holder, now(), now(), null)
+        ON CONFLICT (name) DO UPDATE
+            SET active = true, holder = :holder, heartbeat_at = now(),
+                finished_at = null
+        """
+    )
+    await session.execute(stmt, {"name": name, "holder": holder})

--- a/backend/scheduler/services/visibility_aggregator/runner.py
+++ b/backend/scheduler/services/visibility_aggregator/runner.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2016-2026 Association of Universities for Research in Astronomy, Inc. (AURA)
+# For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+import asyncio
+import os
+import socket
+
+from lucupy.observatory.abstract import ObservatoryProperties
+from lucupy.observatory.gemini.geminiproperties import GeminiProperties
+
+from scheduler.services import logger_factory
+from scheduler.services.sight.database.connection import (
+    dispose_engine,
+    init_db_engine,
+    session_scope,
+)
+from scheduler.services.visibility_aggregator import coordination
+from scheduler.services.visibility_aggregator.aggregator import (
+    is_night_in_progress,
+    run_aggregation,
+)
+
+_logger = logger_factory.create_logger(__name__, with_id=False)
+
+# Refresh the coordination heartbeat at least this often, independent of work
+# granularity, so the operation process's staleness check stays accurate.
+_HEARTBEAT_INTERVAL_SECONDS = 60.0
+
+
+def _holder() -> str:
+    """Identify this run for the coordination row (Heroku dyno id, else host)."""
+    return os.environ.get("DYNO") or socket.gethostname()
+
+
+async def _run() -> int:
+    ObservatoryProperties.set_properties(GeminiProperties)
+    await init_db_engine()
+    try:
+        # Never run while a night is being executed.
+        if is_night_in_progress():
+            _logger.info("A night is in progress; skipping aggregation cycle.")
+            return 0
+
+        async with session_scope() as ctrl:
+            if await coordination.is_plan_in_progress(ctrl):
+                _logger.info(
+                    "Operation process is computing a plan; skipping cycle."
+                )
+                return 0
+            # (2) Atomically claim the aggregator row.
+            acquired = await coordination.acquire_aggregator(ctrl, _holder())
+        if not acquired:
+            _logger.info(
+                "Another aggregator run holds the lock (or it is fresh); "
+                "skipping cycle."
+            )
+            return 0
+
+        stop_heartbeat = asyncio.Event()
+        heartbeat_task = asyncio.create_task(_heartbeat_loop(stop_heartbeat))
+        try:
+            async with session_scope() as work:
+                result = await run_aggregation(
+                    work, heartbeat=_make_detail_heartbeat()
+                )
+            _logger.info(f"Aggregation complete: {result}")
+        finally:
+            stop_heartbeat.set()
+            await heartbeat_task
+            async with session_scope() as release:
+                await coordination.release_aggregator(release)
+        return 0
+    finally:
+        await dispose_engine()
+
+
+def _make_detail_heartbeat():
+    """Heartbeat callback that records progress detail on its own session."""
+    async def _heartbeat(detail: dict) -> None:
+        async with session_scope() as session:
+            await coordination.heartbeat_aggregator(session, detail)
+    return _heartbeat
+
+
+async def _heartbeat_loop(stop: asyncio.Event) -> None:
+    """Keep the coordination row fresh on a fixed cadence until stopped."""
+    while not stop.is_set():
+        try:
+            async with session_scope() as session:
+                await coordination.heartbeat_aggregator(session)
+        except Exception as exc:  # pragma: no cover - heartbeat must not crash run
+            _logger.warning(f"Heartbeat failed: {exc}")
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=_HEARTBEAT_INTERVAL_SECONDS)
+        except asyncio.TimeoutError:
+            pass
+
+
+def main() -> None:
+    """Cron entrypoint for the visibility aggregator.
+
+    Designed to be run by Heroku Scheduler as a one-off dyno:
+
+    $ cd /home && uv run python -m scheduler.services.visibility_aggregator.runner
+
+    Each invocation:
+      1. exits immediately if a night is in progress (dark time at GN/GS) or the
+         operation process is mid plan-computation — so we never run while nights
+         are being executed;
+      2. atomically acquires the ``visibility_aggregator`` coordination row (so two
+         overlapping ticks can't both run, and so the operation process blocks plan
+         creation while we work);
+      3. brings the Sight DB up to date for the current semester (sidereal only),
+         heartbeating throughout;
+      4. always releases the row on the way out.
+    """
+    raise SystemExit(asyncio.run(_run()))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scheduler/services/visibility_aggregator/runner.py
+++ b/backend/scheduler/services/visibility_aggregator/runner.py
@@ -3,11 +3,13 @@
 
 import asyncio
 import os
+import signal
 import socket
 
 from lucupy.observatory.abstract import ObservatoryProperties
 from lucupy.observatory.gemini.geminiproperties import GeminiProperties
 
+from scheduler.config import config
 from scheduler.services import logger_factory
 from scheduler.services.sight.database.connection import (
     dispose_engine,
@@ -24,7 +26,8 @@ _logger = logger_factory.create_logger(__name__, with_id=False)
 
 # Refresh the coordination heartbeat at least this often, independent of work
 # granularity, so the operation process's staleness check stays accurate.
-_HEARTBEAT_INTERVAL_SECONDS = 60.0
+# Configured in config.yaml under `visibility_aggregator`.
+_HEARTBEAT_INTERVAL_SECONDS = float(config.visibility_aggregator.heartbeat_interval_seconds)
 
 
 def _holder() -> str:
@@ -32,8 +35,30 @@ def _holder() -> str:
     return os.environ.get("DYNO") or socket.gethostname()
 
 
+def _install_signal_handlers() -> None:
+    """Cancel the run on SIGTERM/SIGINT so Heroku dyno shutdown releases the
+    coordination row cleanly instead of waiting out the staleness window."""
+    try:
+        loop = asyncio.get_running_loop()
+        main_task = asyncio.current_task()
+    except RuntimeError:  # pragma: no cover - no running loop
+        return
+
+    def _cancel() -> None:
+        _logger.warning("Shutdown signal received; stopping aggregation run.")
+        if main_task is not None:
+            main_task.cancel()
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            loop.add_signal_handler(sig, _cancel)
+        except (NotImplementedError, RuntimeError):  # pragma: no cover
+            pass  # unsupported platform / not the main thread
+
+
 async def _run() -> int:
     ObservatoryProperties.set_properties(GeminiProperties)
+    _install_signal_handlers()
     await init_db_engine()
     try:
         # Never run while a night is being executed.
@@ -47,7 +72,7 @@ async def _run() -> int:
                     "Operation process is computing a plan; skipping cycle."
                 )
                 return 0
-            # (2) Atomically claim the aggregator row.
+            # Atomically claim the aggregator row.
             acquired = await coordination.acquire_aggregator(ctrl, _holder())
         if not acquired:
             _logger.info(
@@ -61,15 +86,41 @@ async def _run() -> int:
         try:
             async with session_scope() as work:
                 result = await run_aggregation(
-                    work, heartbeat=_make_detail_heartbeat()
+                    work,
+                    heartbeat=_make_detail_heartbeat()
                 )
             _logger.info(f"Aggregation complete: {result}")
         finally:
+            # Stop heartbeating and release the row even on cancellation, so the
+            # operation process can resume planning immediately. (Already-committed
+            # batches persist; a killed run resumes from the gaps next tick.)
             stop_heartbeat.set()
-            await heartbeat_task
-            async with session_scope() as release:
-                await coordination.release_aggregator(release)
+            heartbeat_task.cancel()
+            try:
+                await heartbeat_task
+            except asyncio.CancelledError:
+                pass
+            try:
+                async with session_scope() as release:
+                    await coordination.release_aggregator(release)
+            except Exception as exc:
+                _logger.warning(
+                    f"Could not release the coordination row cleanly ({exc}); "
+                    f"it will expire after stale_after_seconds."
+                )
         return 0
+    except asyncio.CancelledError:
+        _logger.warning(
+            "Aggregation run cancelled by shutdown signal; coordination row "
+            "released and progress committed up to the last batch."
+        )
+        return 0
+    except Exception as exc:
+        # e.g. a dropped Heroku Postgres connection mid-run. The row is already
+        # released by the inner finally; committed batches persist, so the next
+        # cron tick resumes from the remaining gaps.
+        _logger.error(f"Aggregation run failed: {exc}", exc_info=True)
+        return 1
     finally:
         await dispose_engine()
 

--- a/changelog.d/GSCHED-973.feature.md
+++ b/changelog.d/GSCHED-973.feature.md
@@ -1,0 +1,1 @@
+Add visibility aggregato background runner for Sight


### PR DESCRIPTION
<!-- CHANGELOG:START -->
### Changelog

**feature** (GSCHED-973): Add visibility aggregato background runner for Sight
<!-- CHANGELOG:END -->

Allows Sight to gather observations offline avoiding dark time from the ODB periodically so is always up to date with the latest data. There are missing features, for example updates on already added observations. 

## Scope

<!-- CI auto-detects this, but it helps reviewers to see at a glance. -->

- [x] Backend (`backend/`)
- [ ] Frontend (`frontend/`)
- [ ] Docs (`docs/`)
- [x] CI/Infra (`.github/`)


<!-- 
  REQUIRED: Add a changelog fragment file to this PR.
  
  Quickest way (auto-detects ticket from branch name):
    ./scripts/changelog-fragment "Your change description"
    ./scripts/changelog-fragment "Your change description" fix
    ./scripts/changelog-fragment "" misc

  Manual:
    echo "Description" > changelog.d/GSCHED-190.feature.md

  Types: feature, fix, breaking, deprecation, improvement, doc, misc
  CI will fail if no fragment is found (unless only CI/docs files changed).
-->


## Jira

<!-- JIRA:START -->
[GSCHED-973](https://noirlab.atlassian.net/browse/GSCHED-973)
<!-- JIRA:END -->

## Checklist

- [x] Changelog fragment added to `changelog.d/`
- [x] Commit messages follow conventional commits (`feat(backend):`, `fix(frontend):`, etc.)
- [x] No breaking changes (or `breaking` fragment added)
