### PR TITLE
fix(backend): Fix Igrins2 observation resources error when None is se…

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -45,8 +45,8 @@ dependencies = [
 ]
 
 [dependency-groups]
-gpp-prod = ["gpp-client>=26.5.0"]
-gpp-dev = ["gpp-client>=26.5.1.dev0,<26.5.1a0"]
+gpp-prod = ["gpp-client>=26.6.0.dev1"]
+gpp-dev = ["gpp-client>=26.6.0.dev1"]
 dev = [
     "hypothesis>=6.137.1",
     "pytest>=8.4.1",

--- a/backend/scheduler/core/programprovider/gpp/gppprogramprovider.py
+++ b/backend/scheduler/core/programprovider/gpp/gppprogramprovider.py
@@ -875,7 +875,10 @@ class GppProgramProvider(ProgramProvider):
             obs_class = ObservationClass.DAYCAL
         # TODO: Do something if observation class is NIGHT_CAL
         # elif 'NIGHT_CAL' in all_classes:
-        #     obs_class = ObservationClass.NIGHTCAL
+        #     obs_class = ObservationClass.NIGHTCAL # Not currently in lucupy
+        # The next 2 lines should be modified when NIGHT_CAL is handled
+        elif 'NIGHT_CAL' in all_classes:
+            obs_class = ObservationClass.PROGCAL
 
         return atoms, obs_class
 
@@ -915,7 +918,7 @@ class GppProgramProvider(ProgramProvider):
 
         # Disperser
         disperser = None
-        if instrument in ['IGRINS', 'MAROON-X', 'GRACES']:
+        if instrument in ['IGRINS2', 'MAROON-X', 'GRACES']:
             disperser = instrument
         # elif GppProgramProvider._AtomKeys.DISPERSER in instrument_config.keys():
         #     disperser = instrument_config[GppProgramProvider._AtomKeys.DISPERSER]

--- a/backend/scheduler/core/programprovider/gpp/gppprogramprovider.py
+++ b/backend/scheduler/core/programprovider/gpp/gppprogramprovider.py
@@ -2,13 +2,11 @@
 # For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 import traceback
-import asyncio
 from datetime import datetime, timedelta
 from dateutil.parser import parse as parsedt
 from astropy.time import Time
-from os import PathLike
 from pathlib import Path
-from typing import FrozenSet, Iterable, List, Mapping, Optional, Tuple, Dict
+from typing import FrozenSet, Iterable, List, Mapping, Optional, Tuple
 
 
 from lucupy.minimodel import (AndOption, Atom, Band, CloudCover, Conditions, Constraints, ElevationType,
@@ -17,20 +15,18 @@ from lucupy.minimodel import (AndOption, Atom, Band, CloudCover, Conditions, Con
                               Program, ProgramID, ProgramMode, ProgramTypes, QAState, ResourceType,
                               ROOT_GROUP_ID, Semester, SemesterHalf, SetupTimeType, SiderealTarget, Site, SkyBackground,
                               Target, TargetTag, TargetName, TargetType, TimeAccountingCode, TimeAllocation, TimeUsed,
-                              TimingWindow, TooType, WaterVapor, Wavelength, Resource, UniqueGroupID, GROUP_NONE_ID,
+                              TimingWindow, TooType, WaterVapor, Wavelength, Resource, GROUP_NONE_ID,
                               CalibrationRole)
 from lucupy.observatory.gemini.geminiobservation import GeminiObservation
 from lucupy.resource_manager import ResourceManager
 from lucupy.timeutils import sex2dec
 from lucupy.types import ZeroTime
-from pandas.core.common import fill_missing_names
 
 from definitions import ROOT_DIR
 from scheduler.clients.gpp import gpp
 from scheduler.core.programprovider.abstract import ProgramProvider
 from scheduler.core.sources.sources import Sources
 from scheduler.services import logger_factory
-
 
 __all__ = [
     'GppProgramProvider',
@@ -136,7 +132,7 @@ class GppProgramProvider(ProgramProvider):
     _NIFS_FILTER_WAVELENGTHS = {'ZJ': 1.05, 'JH': 1.25, 'HK': 2.20}
     _CAL_OBSERVE_TYPES = frozenset(['FLAT', 'ARC', 'DARK', 'BIAS'])
 
-    _site_for_inst = {'GMOS_NORTH': Site.GN, 'GMOS_SOUTH': Site.GS, 'FLAMINGOS2': Site.GS}
+    _site_for_inst = {'GMOS_NORTH': Site.GN, 'GMOS_SOUTH': Site.GS, 'FLAMINGOS2': Site.GS, 'IGRINS2': Site.GN}
 
     _gmos_filters = {'GMOS-S': ['U_PRIME', 'G_PRIME', 'R_PRIME', 'I_PRIME', 'Z_PRIME', 'Z', 'Y', 'GG455', 'OG515',
                                     'RG610', 'CA_T', 'F396N', 'OIII', 'OIIIC', 'HE_II', 'HE_IIC', 'OVI', 'OVIC',
@@ -150,7 +146,7 @@ class GppProgramProvider(ProgramProvider):
     _OBSERVATION_STATUSES = frozenset({ObservationStatus.READY, ObservationStatus.ONGOING})
 
     # Translate instrument names to use the OCS Resources
-    _gpp_inst_to_ocs = {'GMOS_NORTH': 'GMOS-N', 'GMOS_SOUTH': 'GMOS-S', 'FLAMINGOS2': 'Flamingos2'}
+    _gpp_inst_to_ocs = {'GMOS_NORTH': 'GMOS-N', 'GMOS_SOUTH': 'GMOS-S', 'FLAMINGOS2': 'Flamingos2', 'IGRINS2': 'IGRINS2'}
 
     # GPP GMOS built-in GPU name to barcode
     # ToDo: Eventually this needs to come from another source, e.g. Resource, ICTD, decide whether to use name or barcode
@@ -396,14 +392,14 @@ class GppProgramProvider(ProgramProvider):
     }
 
     DISPERSER_FOR_INSTRUMENT = {
-        # 'GSAOI': _FPUKeys.GSAOI,
-        # 'GPI': _FPUKeys.GPI,
+        # 'GSAOI': _DISPKeys.GSAOI,
+        # 'GPI': _DISPKeys.GPI,
         'Flamingos2': _DISPKeys.F2,
-        # 'NIFS': _FPUKeys.NIFS,
-        # 'GNIRS': _FPUKeys.GNIRS,
+        # 'NIFS': _DISPKeys.NIFS,
+        # 'GNIRS': _DISPKeys.GNIRS,
         'GMOS-N': _DISPKeys.GMOSN,
         'GMOS-S': _DISPKeys.GMOSS,
-        # 'NIRI': _FPUKeys.NIRI
+        # 'NIRI': _DISPKeys.NIRI
     }
 
     # An empty base target for when the target environment is empty for an Observation.
@@ -773,7 +769,7 @@ class GppProgramProvider(ProgramProvider):
 
         # Disperser
         disperser = None
-        if instrument in ['IGRINS', 'MAROON-X', 'GRACES']:
+        if instrument in ['IGRINS', 'MAROON-X', 'GRACES']: # TODO Should add IGRINS2?
             disperser = instrument
         elif instrument in GppProgramProvider.DISPERSER_FOR_INSTRUMENT:
             disperser = data[GppProgramProvider.DISPERSER_FOR_INSTRUMENT[instrument]]
@@ -877,6 +873,9 @@ class GppProgramProvider(ProgramProvider):
             obs_class = ObservationClass.PARTNERCAL
         elif 'DAY_CAL' in all_classes:
             obs_class = ObservationClass.DAYCAL
+        # TODO: Do something if observation class is NIGHT_CAL
+        # elif 'NIGHT_CAL' in all_classes:
+        #     obs_class = ObservationClass.NIGHTCAL
 
         return atoms, obs_class
 
@@ -979,7 +978,7 @@ class GppProgramProvider(ProgramProvider):
             instrument, resource_type=ResourceType.INSTRUMENT
         )])
 
-        resources = frozenset([r for r in instrument_resource | fpu_resources | disperser_resources | filter_resources])
+        resources = frozenset([r for r in instrument_resource | fpu_resources | disperser_resources | filter_resources if r is not None])
         # Remove any None values.
         # resources = frozenset([res for res in resources if res is not None])
         # print(f'resources: {resources}')
@@ -1216,11 +1215,14 @@ class GppProgramProvider(ProgramProvider):
 
         except KeyError as ex:
             logger.error(f'KeyError while reading {obs_id}: {ex} (skipping).')
+            traceback.print_exc()
         except ValueError as ex:
             logger.error(f'ValueError while reading {obs_id}: {ex} (skipping).')
+            traceback.print_exc()
 
         except Exception as ex:
             logger.error(f'Unexpected exception while reading {obs_id}: {ex} (skipping).')
+            traceback.print_exc()
         return None
 
     def parse_group(self, data: dict, program_id: ProgramID, group_id: GroupID,

--- a/changelog.d/GSCHED-979.fix.md
+++ b/changelog.d/GSCHED-979.fix.md
@@ -1,0 +1,1 @@
+Igrins2 observations are parsed and some resources are set to None

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -188,7 +188,7 @@ version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "frozenlist" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'group-9-scheduler-gpp-dev' and extra == 'group-9-scheduler-gpp-prod')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
@@ -231,7 +231,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
     { name = "sniffio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'group-9-scheduler-gpp-dev' and extra == 'group-9-scheduler-gpp-prod')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f1/b4/636b3b65173d3ce9a38ef5f0522789614e590dab6a8d505340a4efe4c567/anyio-4.10.0.tar.gz", hash = "sha256:3f3fae35c96039744587aa5b8371e7e8e603c0702999535961dd336026973ba6", size = 213252, upload-time = "2025-08-04T08:54:26.451Z" }
 wheels = [
@@ -498,7 +498,7 @@ name = "click"
 version = "8.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'group-9-scheduler-gpp-dev' and extra == 'group-9-scheduler-gpp-prod')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
 wheels = [
@@ -917,7 +917,7 @@ wheels = [
 
 [[package]]
 name = "gpp-client"
-version = "26.5.1.dev2"
+version = "26.6.0.dev1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -929,9 +929,9 @@ dependencies = [
     { name = "typer" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/db/6b1e69de1a2d0df858e5cb872fe5fcea0494c8c2e6cbad38e4cc61857989/gpp_client-26.5.1.dev2.tar.gz", hash = "sha256:8445bc92f1a2ab42d1fec98cd7df52790e0bfb990bb612b17d18e30de1234b2f", size = 176497, upload-time = "2026-05-13T19:11:43.718Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/56/3960bebca9573caa30156bef15fab7c2596b25ea5d91ff2dfaf02abfdc44/gpp_client-26.6.0.dev1.tar.gz", hash = "sha256:52123b45f466c9f72942f3caf3923c156e084527ac3129a4c32f3703a7dee186", size = 185030, upload-time = "2026-06-10T20:00:18.679Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/6e/b178dafc49ae8064599314c3ab206278c9320ad4338d788609fe350bf6e2/gpp_client-26.5.1.dev2-py3-none-any.whl", hash = "sha256:e760e05620cfbe3868cfaa59af77a85f71a3cc1241f117acc8ad6da247eae6f4", size = 214225, upload-time = "2026-05-13T19:11:42.301Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/17/decbf85769863585d630c07acc9785c9c3f80cc6b604b56ea39efdbb3151/gpp_client-26.6.0.dev1-py3-none-any.whl", hash = "sha256:084b345bcd0bf193c6ede5e2342d926c6ece63b85fd0615871377d14ccc7b491", size = 222674, upload-time = "2026-06-10T20:00:19.674Z" },
 ]
 
 [[package]]
@@ -2807,8 +2807,8 @@ docs = [
     { name = "mkdocs-mermaid2-plugin", specifier = ">=1.2.1" },
     { name = "mkdocstrings-python", specifier = ">=1.16.12" },
 ]
-gpp-dev = [{ name = "gpp-client", specifier = ">=26.5.1.dev0,<26.5.1a0" }]
-gpp-prod = [{ name = "gpp-client", specifier = ">=26.5.0" }]
+gpp-dev = [{ name = "gpp-client", specifier = ">=26.6.0.dev1" }]
+gpp-prod = [{ name = "gpp-client", specifier = ">=26.6.0.dev1" }]
 
 [[package]]
 name = "scipy"


### PR DESCRIPTION
<!-- CHANGELOG:START -->
### Changelog

**fix** (GSCHED-979): Igrins2 observations are parsed and some resources are set to None
<!-- CHANGELOG:END -->

…t to fpu and disperser

## Scope

<!-- CI auto-detects this, but it helps reviewers to see at a glance. -->

- [ ] Backend (`backend/`)
- [ ] Frontend (`frontend/`)
- [ ] Docs (`docs/`)
- [ ] CI/Infra (`.github/`)


<!-- 
  REQUIRED: Add a changelog fragment file to this PR.
  
  Quickest way (auto-detects ticket from branch name):
    ./scripts/changelog-fragment "Your change description"
    ./scripts/changelog-fragment "Your change description" fix
    ./scripts/changelog-fragment "" misc

  Manual:
    echo "Description" > changelog.d/GSCHED-190.feature.md

  Types: feature, fix, breaking, deprecation, improvement, doc, misc
  CI will fail if no fragment is found (unless only CI/docs files changed).
-->


## Jira

<!-- JIRA:START -->
<!-- Auto-linked from branch name (e.g. GSCHED-190/description) by the PR Jira Link workflow. -->
<!-- JIRA:END -->

## Checklist

- [ ] Changelog fragment added to `changelog.d/`
- [ ] Commit messages follow conventional commits (`feat(backend):`, `fix(frontend):`, etc.)
- [ ] No breaking changes (or `breaking` fragment added)
