### PR TITLE
fix(backend): Add IGRINS-2 acquisition overhead

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scheduler"
-version = "0.1.12"
+version = "0.1.13"
 description = "Gemini Observatory automated scheduler"
 readme = 'README.md'
 authors = [{ name = "NOIRLab" }]
@@ -16,7 +16,7 @@ dependencies = [
     "gql>=4.0.0",
     "hypothesis>=6.137.1",
     "joblib>=1.5.2",
-    "lucupy>=0.2.9",
+    "lucupy>=0.2.10",
     "matplotlib>=3.10.5",
     "more-itertools>=10.7.0",
     "numpy>=2.3.2",

--- a/backend/scheduler/core/programprovider/gpp/gppprogramprovider.py
+++ b/backend/scheduler/core/programprovider/gpp/gppprogramprovider.py
@@ -919,11 +919,11 @@ class GppProgramProvider(ProgramProvider):
 
         # Disperser
         disperser = None
-        if instrument in ['IGRINS', 'MAROON-X', 'GRACES']:
-            disperser = instrument
+        # if instrument in ['IGRINS', 'MAROON-X', 'GRACES']:
+        #     disperser = instrument
         # elif GppProgramProvider._AtomKeys.DISPERSER in instrument_config.keys():
         #     disperser = instrument_config[GppProgramProvider._AtomKeys.DISPERSER]
-        elif instrument in GppProgramProvider.DISPERSER_FOR_INSTRUMENT and 'SLIT' in mode:
+        if instrument in GppProgramProvider.DISPERSER_FOR_INSTRUMENT and 'SLIT' in mode:
             disperser = instrument_config[GppProgramProvider.DISPERSER_FOR_INSTRUMENT[instrument]]
         elif 'GMOS' in instrument and 'IMAGING' in mode:
             disperser = 'Mirror'
@@ -1095,6 +1095,9 @@ class GppProgramProvider(ProgramProvider):
             elif 'FLAM' in mode:
                 if 'SLIT' in mode:
                     acq_overhead = timedelta(seconds=20 * 60)
+            elif "IGRINS" in mode:
+                if "SLIT" in mode:
+                    acq_overhead = timedelta(seconds=7 * 60)
             # print(f'\t\t acq_overhead: {acq_overhead}')
 
             # Atoms

--- a/changelog.d/GSCHED-981.fix.md
+++ b/changelog.d/GSCHED-981.fix.md
@@ -1,0 +1,1 @@
+Add IGRINS-2 acquisition overhead

--- a/uv.lock
+++ b/uv.lock
@@ -1419,7 +1419,7 @@ wheels = [
 
 [[package]]
 name = "lucupy"
-version = "0.2.9"
+version = "0.2.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astropy" },


### PR DESCRIPTION
For now the acq overheads have to be hard coded. These should really come from the ODB query. With the lucupy update the IGRINS-2 tellurics will be scheduled with the science.

## Scope

<!-- CI auto-detects this, but it helps reviewers to see at a glance. -->

- [ ] Backend (`backend/`)
- [ ] Frontend (`frontend/`)
- [ ] Docs (`docs/`)
- [ ] CI/Infra (`.github/`)


<!-- 
  REQUIRED: Add a changelog fragment file to this PR.
  
  Quickest way (auto-detects ticket from branch name):
    ./scripts/changelog-fragment "Your change description"
    ./scripts/changelog-fragment "Your change description" fix
    ./scripts/changelog-fragment "" misc

  Manual:
    echo "Description" > changelog.d/GSCHED-190.feature.md

  Types: feature, fix, breaking, deprecation, improvement, doc, misc
  CI will fail if no fragment is found (unless only CI/docs files changed).
-->


## Jira

<!-- JIRA:START -->
<!-- Auto-linked from branch name (e.g. GSCHED-190/description) by the PR Jira Link workflow. -->
<!-- JIRA:END -->

## Checklist

- [ ] Changelog fragment added to `changelog.d/`
- [ ] Commit messages follow conventional commits (`feat(backend):`, `fix(frontend):`, etc.)
- [ ] No breaking changes (or `breaking` fragment added)
