### PR TITLE
fix(backend): gppprogramprovider updated to parse programs

### DIFF
--- a/backend/scheduler/core/programprovider/gpp/gppprogramprovider.py
+++ b/backend/scheduler/core/programprovider/gpp/gppprogramprovider.py
@@ -1526,7 +1526,7 @@ class GppProgramProvider(ProgramProvider):
             prog_type = gpp_prog_type[0:3]
         elif gpp_prog_type.name == 'SCIENCE':
             # TODO: switch to interfaces
-            gpp_prop_subtype = data['proposal']['type_']['science_subtype']
+            gpp_prop_subtype = data['proposal']['gemini']['science_subtype']
             prog_type = self._gpp_prop_type[gpp_prop_subtype]
 
         program_type = ProgramTypes[prog_type]  # Program.Proposal.type.science_subtype

--- a/changelog.d/GSCHED-990.fix.md
+++ b/changelog.d/GSCHED-990.fix.md
@@ -1,0 +1,1 @@
+Program schema has changed, subtype is not part of the key type anymore, it was separated in multiple options, use gemini fragment


### PR DESCRIPTION
<!-- CHANGELOG:START -->
### Changelog

**fix** (GSCHED-990): Program schema has changed, subtype is not part of the key type anymore, it was separated in multiple options, use gemini fragment
<!-- CHANGELOG:END -->

The program -> proposal content has changed, there is no `type` key anymore, I updated the program parse to take the `scienceSubtype` from the `gemini` proposal type.
I don't know if this is the way to go or if we should implement some logic to get it from all observatories `keck`, `subaru` and `gemini`

## Scope

<!-- CI auto-detects this, but it helps reviewers to see at a glance. -->

- [x] Backend (`backend/`)
- [ ] Frontend (`frontend/`)
- [ ] Docs (`docs/`)
- [ ] CI/Infra (`.github/`)


<!-- 
  REQUIRED: Add a changelog fragment file to this PR.
  
  Quickest way (auto-detects ticket from branch name):
    ./scripts/changelog-fragment "Your change description"
    ./scripts/changelog-fragment "Your change description" fix
    ./scripts/changelog-fragment "" misc

  Manual:
    echo "Description" > changelog.d/GSCHED-190.feature.md

  Types: feature, fix, breaking, deprecation, improvement, doc, misc
  CI will fail if no fragment is found (unless only CI/docs files changed).
-->


## Jira

<!-- JIRA:START -->
[GSCHED-990](https://noirlab.atlassian.net/browse/GSCHED-990)
<!-- JIRA:END -->

## Checklist

- [ ] Changelog fragment added to `changelog.d/`
- [ ] Commit messages follow conventional commits (`feat(backend):`, `fix(frontend):`, etc.)
- [ ] No breaking changes (or `breaking` fragment added)
