### PR TITLE
ci: modify promotion releases to remove conflict with bumping version and Changelog

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,143 @@
+###############################################################################
+# Prepare Release
+# Manual trigger. Opens a reviewable release PR instead of pushing to main
+# (main is protected — direct pushes are rejected).
+#
+# What it does:
+#   1. Computes the next CalVer version (YYYY.MM.PATCH) and bumps version.py
+#   2. Builds CHANGELOG.md with towncrier (consumes changelog.d/ fragments)
+#   3. Opens a release/vX.Y.Z PR against main for review
+#
+# Merging the PR automatically triggers "Promote to PROD", which deploys,
+# tags, and publishes the GitHub Release.
+#
+###############################################################################
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_override:
+        description: "Override version (leave empty to auto-compute next CalVer)"
+        required: false
+        type: string
+
+concurrency:
+  group: prepare-release
+  cancel-in-progress: false
+
+jobs:
+  prepare-release:
+    name: Prepare Release PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - uses: ./.github/actions/setup-uv
+        with:
+          python-version: "3.11"
+
+      - name: Compute next version
+        id: version
+        run: |
+          if [ -n "${{ inputs.version_override }}" ]; then
+            VERSION="${{ inputs.version_override }}"
+          else
+            CURRENT=$(python3 -c "from version import __version__; print(__version__)")
+            NOW=$(date -u +%Y.%m)
+            if [[ "$CURRENT" == "$NOW".* ]]; then
+              PATCH=$(( ${CURRENT##*.} + 1 ))
+            else
+              PATCH=1
+            fi
+            VERSION="${NOW}.${PATCH}"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Preparing release: ${VERSION}"
+
+      - name: Fail if tag already exists
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if git ls-remote --tags origin "refs/tags/v$VERSION" | grep -q .; then
+            echo "::error::Tag v$VERSION already exists. Use version_override to pick another version."
+            exit 1
+          fi
+
+      - name: Bump version.py
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          sed -i "s/^__version__ = .*/__version__ = \"$VERSION\"/" version.py
+          cat version.py
+
+      - name: Render changelog preview
+        id: changelog
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          CHANGELOG=$(uv run towncrier build --version "$VERSION" --draft)
+          {
+            echo "changelog<<EOF"
+            echo "$CHANGELOG"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build changelog and consume fragments
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          uv run towncrier build --version "$VERSION" --yes
+
+      - name: Open release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+          CHANGELOG: ${{ steps.changelog.outputs.changelog }}
+        run: |
+          BRANCH="release/v$VERSION"
+
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "::error::Nothing to release — no changelog or version changes were produced."
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git add -A
+          git commit -m "chore(release): prepare v$VERSION"
+          # --force makes re-runs of this workflow refresh the branch
+          git push --force origin "$BRANCH"
+
+          BODY_FILE="$RUNNER_TEMP/pr_body.md"
+          {
+            echo "## Release v$VERSION"
+            echo ""
+            echo "Prepared by @$GITHUB_ACTOR via the **Prepare Release** workflow."
+            echo ""
+            echo "Review the changelog and version bump below. **Merging this PR"
+            echo "automatically triggers the"
+            echo "[Promote to PROD]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/workflows/promote-prod.yml)"
+            echo "workflow**, which deploys to production, tags \`v$VERSION\`, and"
+            echo "publishes the GitHub Release. Close this PR instead of merging if"
+            echo "you are not ready to deploy."
+            echo ""
+            echo "---"
+            echo ""
+            echo "$CHANGELOG"
+          } > "$BODY_FILE"
+
+          EXISTING=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')
+          if [ -z "$EXISTING" ]; then
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "release: v$VERSION" \
+              --body-file "$BODY_FILE"
+          else
+            echo "PR #$EXISTING already exists for $BRANCH — updating its body."
+            gh pr edit "$EXISTING" --body-file "$BODY_FILE"
+          fi

--- a/.github/workflows/promote-prod.yml
+++ b/.github/workflows/promote-prod.yml
@@ -1,26 +1,28 @@
 ###############################################################################
 # Promote to PRODUCTION
-# Manual trigger with approval gate.
+# Runs automatically when a release/* PR (opened by "Prepare Release") is
+# merged into main — the PR review is the manual gate. Can also be triggered
+# manually via workflow_dispatch as a fallback (e.g. to retry a failed run).
 # ALWAYS deploys both backend and frontend (full promotion).
 #
+# This workflow verifies the changelog for the current version is already
+# merged, checks the Heroku apps are set up, deploys, then creates the git
+# tag and GitHub Release via the API — it never pushes to main.
+#
 # GitHub Environments used:
-#   - prod-backend  → approval required, shows backend API URL
-#   - prod-frontend → approval required, shows frontend URL
+#   - prod-backend  → shows backend API URL
+#   - prod-frontend → shows frontend URL
+# If required reviewers are configured on these environments the deploy jobs
+# pause for approval; remove them in Settings → Environments for a fully
+# automatic promotion after the release PR merge.
 ###############################################################################
 name: Promote to PROD
 
 on:
   workflow_dispatch:
-    inputs:
-      version_bump:
-        description: "Override version (leave empty to use current)"
-        required: false
-        type: string
-      skip_changelog:
-        description: "Skip changelog generation"
-        required: false
-        type: boolean
-        default: false
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 concurrency:
   group: deploy-prod
@@ -30,67 +32,107 @@ jobs:
   preflight:
     name: Pre-flight Checks
     runs-on: ubuntu-latest
+    # Run on manual dispatch, or automatically when a release PR is merged.
+    # All other jobs depend on this one, so they inherit the condition.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       startsWith(github.event.pull_request.head.ref, 'release/'))
+    env:
+      HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
     outputs:
       version: ${{ steps.version.outputs.version }}
       changelog: ${{ steps.changelog.outputs.changelog }}
+      sha: ${{ steps.sha.outputs.sha }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: main
 
-      - uses: ./.github/actions/setup-uv
-        with:
-          python-version: "3.11"
+      - name: Record deployed commit
+        id: sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Determine version
         id: version
         run: |
-          if [ -n "${{ inputs.version_bump }}" ]; then
-            VERSION="${{ inputs.version_bump }}"
-          else
-            VERSION=$(uv run python -c "
-          try:
-              import tomllib
-              with open('pyproject.toml', 'rb') as f:
-                  data = tomllib.load(f)
-              print(data['project']['version'])
-          except:
-              from version import __version__
-              print(__version__)
-          ")
-          fi
+          VERSION=$(python3 -c "from version import __version__; print(__version__)")
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Deploying version: ${VERSION}"
-      ###################################################
-      #
-      ###################################################
-      #- name: Verify CI passed on main
-      #  run: |
+          echo "Promoting version: ${VERSION}"
 
-      #    CONCLUSION=$(gh run list \
-      #      --branch main \
-      #      --workflow ci.yml \
-      #      --limit 1 \
-      #      --json conclusion \
-      #     --jq '.[0].conclusion')
-      #    if [ "$CONCLUSION" != "success" ]; then
-      #      echo "::error::CI has not passed on main. Aborting promotion."
-      #      exit 1
-      #    fi
-      #    echo "CI passed on main"
-      #  env:
-      #    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build changelog (dry run)
-        id: changelog
-        if: ${{ !inputs.skip_changelog }}
+      - name: Verify release PR was merged
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          CHANGELOG=$(uv run towncrier build --version "$VERSION" --draft 2>/dev/null || echo "No changelog fragments found.")
-          echo "changelog<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$CHANGELOG" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          if ! grep -q "^## $VERSION " CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no entry for $VERSION. Run the 'Prepare Release' workflow and merge the release PR before promoting."
+            exit 1
+          fi
+          if git ls-remote --tags origin "refs/tags/v$VERSION" | grep -q .; then
+            echo "::error::Tag v$VERSION already exists — this version was already released. Run 'Prepare Release' to cut a new version."
+            exit 1
+          fi
+          echo "Release v$VERSION is ready to promote."
+
+      - name: Extract changelog section
+        id: changelog
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          SECTION=$(awk -v ver="$VERSION" '
+            $0 ~ "^## "ver" " { found=1; next }
+            /^## / && found { exit }
+            found { print }
+          ' CHANGELOG.md)
+          {
+            echo "changelog<<EOF"
+            echo "$SECTION"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Install Heroku CLI
+        run: curl https://cli-assets.heroku.com/install.sh | sh
+
+      - name: Verify Heroku apps are set up
+        env:
+          APP_REALTIME: ${{ secrets.HEROKU_APP_NAME_REALTIME_PRODUCTION }}
+          APP_MULTINIGHT: ${{ secrets.HEROKU_APP_NAME_MULTINIGHT_PRODUCTION }}
+          APP_FRONTEND: ${{ secrets.HEROKU_APP_NAME_FRONTEND_PRODUCTION }}
+        run: |
+          FAILED=0
+
+          check_app() {
+            local label="$1" app="$2" want_container="$3"
+            if [ -z "$app" ]; then
+              echo "::error::Secret for $label app is empty. Set it in the repository secrets."
+              FAILED=1
+              return
+            fi
+            if ! INFO=$(heroku apps:info --json -a "$app" 2>&1); then
+              echo "::error::Cannot reach Heroku app '$app' ($label): $INFO"
+              FAILED=1
+              return
+            fi
+            STACK=$(echo "$INFO" | jq -r .app.stack.name)
+            echo "✓ $label: app '$app' exists (stack: $STACK)"
+            if [ "$want_container" = "true" ] && [ "$STACK" != "container" ]; then
+              echo "::error::$label app '$app' uses stack '$STACK' but container deploys require the 'container' stack."
+              FAILED=1
+              return
+            fi
+            if [ "$want_container" = "true" ] && [ -z "$(heroku config:get DATABASE_URL -a "$app")" ]; then
+              echo "::warning::$label app '$app' has no DATABASE_URL — migrations will be skipped."
+            fi
+          }
+
+          check_app "realtime backend" "$APP_REALTIME" true
+          check_app "multinight backend" "$APP_MULTINIGHT" true
+          check_app "frontend" "$APP_FRONTEND" false
+
+          if [ "$FAILED" -ne 0 ]; then
+            echo "::error::Heroku setup checks failed — fix the issues above before promoting."
+            exit 1
+          fi
+          echo "All Heroku setup checks passed."
 
   deploy-backend:
     name: "Deploy Backend → PROD"
@@ -118,27 +160,8 @@ jobs:
         run: |
           echo "Checking LFS status:"
           git lfs ls-files
-          echo "Checking if LFS files exist locally:" 
+          echo "Checking if LFS files exist locally:"
           ls -la backend/scheduler/services/horizons/data/
-
-      - uses: ./.github/actions/setup-uv
-        with:
-          python-version: "3.11"
-
-      - name: Extract version
-        id: version
-        run: |
-          VERSION=$(uv run python -c "
-          try:
-              import tomllib
-              with open('pyproject.toml', 'rb') as f:
-                  data = tomllib.load(f)
-              print(data['project']['version'])
-          except:
-              from version import __version__
-              print(__version__)
-          ")
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Install Heroku CLI
         run: curl https://cli-assets.heroku.com/install.sh | sh
@@ -151,7 +174,7 @@ jobs:
         run: |
           heroku container:push -a ${{ secrets[matrix.app_secret] }} web \
             --context-path .. \
-            --arg APP_VERSION=${{ steps.version.outputs.version }}-prod-${{ matrix.mode }},GPP_GROUP=gpp-prod
+            --arg APP_VERSION=${{ needs.preflight.outputs.version }}-prod-${{ matrix.mode }},GPP_GROUP=gpp-prod
 
       - name: Release container on Heroku
         run: |
@@ -193,61 +216,27 @@ jobs:
           buildpack: heroku-community/nginx
 
   release:
-    name: Create Release
+    name: Create GitHub Release
     runs-on: ubuntu-latest
     needs: [preflight, deploy-backend, deploy-frontend]
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: ./.github/actions/setup-uv
-        with:
-          python-version: "3.11"
-
-      - name: Build changelog and consume fragments
-        run: |
-          VERSION="${{ needs.preflight.outputs.version }}"
-          uv run towncrier build --version "$VERSION" --yes
-
-      - name: Commit changelog and removed fragments
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md changelog.d/
-          git diff --cached --quiet || \
-            git commit -m "docs: update changelog for v${{ needs.preflight.outputs.version }} [skip ci]"
-          git push origin main
-
-      - name: Create Git tag
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${{ needs.preflight.outputs.version }}" \
-            -m "Release v${{ needs.preflight.outputs.version }}"
-          git push origin "v${{ needs.preflight.outputs.version }}"
-
-      - name: Create GitHub Release
+      - name: Create tag and GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ needs.preflight.outputs.version }}
+          target_commitish: ${{ needs.preflight.outputs.sha }}
           name: v${{ needs.preflight.outputs.version }}
           body: |
             ## Release v${{ needs.preflight.outputs.version }}
 
-            **Deployed:** ${{ github.event.head_commit.timestamp || 'manual trigger' }}
-            **Deployed by:** ${{ github.actor }}
+            **Deployed by:** @${{ github.actor }}
 
             ### Deployed to
-            - ✅ Backend
+            - ✅ Backend (realtime + multinight)
             - ✅ Frontend
 
             ${{ needs.preflight.outputs.changelog }}
-
-            ---
-            _Full diff: [${{ github.event.before || 'previous' }}...${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/compare/${{ github.event.before || 'HEAD~1' }}...${{ github.sha }})_
           draft: false
           prerelease: false

--- a/DEV-GUIDE.MD
+++ b/DEV-GUIDE.MD
@@ -24,11 +24,23 @@ Current branch structure. We are still going to be using a main branch to hold b
                           Ready for production?
                                     │
                                     ▼
-                          Actions → "Promote to PROD"
+                          Actions → "Prepare Release"
                            (manual trigger only)
                                     │
                                     ▼
-                          Version bump + tag (auto)
+                        release/vX PR to main
+                    (CalVer bump + CHANGELOG.md)
+                                    │
+                                    ▼
+                            Review & merge PR
+                                    │
+                                    ▼
+                        "Promote to PROD" auto-runs
+                         (merge is the trigger)
+                                    │
+                                    ▼
+                        Pre-flight: release merged?
+                          Heroku apps set up?
                                     │
                                     ▼
                               Approval gate
@@ -40,7 +52,8 @@ Current branch structure. We are still going to be using a main branch to hold b
                           │         │         │
                           └─────────┼─────────┘
                                     ▼
-                          GitHub Release + Changelog
+                          Tag + GitHub Release
+                        (from merged changelog)
 
 ```
 
@@ -101,22 +114,32 @@ The arg is passed via `heroku container:push --arg GPP_GROUP=…`. If you build 
 
 ## Promoting to Production
 
+Releasing is a two-step flow: first a reviewable release PR, then the actual promotion. The workflows never push to `main` directly (it is a protected branch).
+
+### Step 1 — Prepare the release
+
 1. Verify dev is working as expected
 
-2. Go to Actions → "Promote to PROD" → Run workflow
+2. Go to Actions → "Prepare Release" → Run workflow
 
-3. Optionally check "dry run" first to preview
+3. The workflow computes the next CalVer version, bumps `version.py`, builds `CHANGELOG.md` with towncrier (consuming the `changelog.d/` fragments), and opens a `release/vX.Y.Z` PR against `main`
 
-4. Approver accepts the environment gate
+4. Review the PR — it shows exactly what will be released — then approve and merge it. **Merging is the deploy trigger**; close the PR instead if you are not ready to ship
 
-5. All components deploy to prod
+### Step 2 — Promotion (automatic)
 
-6. Tag created, GitHub Release published with changelog
+Merging the `release/*` PR automatically triggers "Promote to PROD" (it can also be run manually from the Actions tab as a fallback, e.g. to retry a failed run):
+
+1. Pre-flight checks run first: the `CHANGELOG.md` entry for the current version must exist (and the tag must not), and the Heroku production apps are verified (apps reachable, backend apps on the `container` stack, `DATABASE_URL` present)
+
+2. All components deploy to prod. If required reviewers are configured on the `prod-backend`/`prod-frontend` environments, the deploy jobs pause for approval — remove them in Settings → Environments for a fully automatic promotion
+
+3. Tag `vX.Y.Z` is created and the GitHub Release is published (Releases tab) with the changelog section from the merged release PR
 
 ## Versioning: CalVer
 
 Format: YYYY.MM.PATCH (e.g., 2026.04.1, 2026.04.2, 2026.05.1)
 
-The "Create Release Tag" workflow auto-calculates the next version. Within the same month, patch increments. New month resets to 1. You can override with a specific version.
+The "Prepare Release" workflow auto-calculates the next version from `version.py`. Within the same month, patch increments. New month resets to 1. You can override with a specific version via the `version_override` input.
 
 Tags are the source of truth for what's in production.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -71,45 +71,5 @@ conflicts = [
 ]
 
 
-[tool.towncrier]
-package = "version"
-package_dir = "."
-filename = "CHANGELOG.md"
-directory = "changelog.d"
-title_format = "## {version} ({project_date})"
-template = "changelog.d/_template.md.jinja2"
-
-[[tool.towncrier.type]]
-directory = "feature"
-name = "Features"
-showcontent = true
-
-[[tool.towncrier.type]]
-directory = "fix"
-name = "Bug Fixes"
-showcontent = true
-
-[[tool.towncrier.type]]
-directory = "breaking"
-name = "Breaking Changes"
-showcontent = true
-
-[[tool.towncrier.type]]
-directory = "deprecation"
-name = "Deprecations"
-showcontent = true
-
-[[tool.towncrier.type]]
-directory = "improvement"
-name = "Improvements"
-showcontent = true
-
-[[tool.towncrier.type]]
-directory = "doc"
-name = "Documentation"
-showcontent = true
-
-[[tool.towncrier.type]]
-directory = "misc"
-name = "Internal Changes"
-showcontent = false
+# Towncrier config moved to towncrier.toml at the repo root so it is
+# picked up when towncrier runs from the root (where changelog.d/ lives).

--- a/changelog.d/GSCHED-986.fix.md
+++ b/changelog.d/GSCHED-986.fix.md
@@ -1,0 +1,1 @@
+Fix the release process: changelog is now built in a reviewable release PR (Prepare Release workflow) instead of pushing to the protected main branch, promotion pre-flight verifies the Heroku app setup, and the GitHub Release is created via the API

--- a/changelog.d/_template.md.jinja2
+++ b/changelog.d/_template.md.jinja2
@@ -1,19 +1,19 @@
 {% for section, _ in sections.items() %}
-{% set underline = "#" %}
-{% if sections.keys()|list|length > 1 %}
+{% if section %}
+### {{ section }}
 
-{{ versiondata.version }} ({{ versiondata.date }})
-{{ underline * ((versiondata.version ~ " (" ~ versiondata.date ~ ")")|length) }}
-{% else %}
 {% endif %}
-{% if sections.keys()|list|length > 1 %}{{ section }}
-{{ underline * section|length }}{% endif %}
+{% if sections[section] %}
 {% for category, val in definitions.items() if category in sections[section] %}
-
 ### {{ definitions[category]['name'] }}
 
 {% for text, values in sections[section][category].items() %}
-- {% if text %}{{ text }}{% else %}{{ values|join(', ') }}{% endif %}
+- {{ text if text else values|join(', ') }}
 {% endfor %}
+
 {% endfor %}
+{% else %}
+No significant changes.
+
+{% endif %}
 {% endfor %}

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -24,11 +24,23 @@ Current branch structure. We are still going to be using a main branch to hold b
                           Ready for production?
                                     │
                                     ▼
-                          Actions → "Promote to PROD"
+                          Actions → "Prepare Release"
                            (manual trigger only)
                                     │
                                     ▼
-                          Version bump + tag (auto)
+                        release/vX PR to main
+                    (CalVer bump + CHANGELOG.md)
+                                    │
+                                    ▼
+                            Review & merge PR
+                                    │
+                                    ▼
+                        "Promote to PROD" auto-runs
+                         (merge is the trigger)
+                                    │
+                                    ▼
+                        Pre-flight: release merged?
+                          Heroku apps set up?
                                     │
                                     ▼
                               Approval gate
@@ -40,7 +52,8 @@ Current branch structure. We are still going to be using a main branch to hold b
                           │         │         │
                           └─────────┼─────────┘
                                     ▼
-                          GitHub Release + Changelog
+                          Tag + GitHub Release
+                        (from merged changelog)
 
 ```
 
@@ -101,22 +114,32 @@ The arg is passed via `heroku container:push --arg GPP_GROUP=…`. If you build 
 
 ## Promoting to Production
 
+Releasing is a two-step flow: first a reviewable release PR, then the actual promotion. The workflows never push to `main` directly (it is a protected branch).
+
+### Step 1 — Prepare the release
+
 1. Verify dev is working as expected
 
-2. Go to Actions → "Promote to PROD" → Run workflow
+2. Go to Actions → "Prepare Release" → Run workflow
 
-3. Optionally check "dry run" first to preview
+3. The workflow computes the next CalVer version, bumps `version.py`, builds `CHANGELOG.md` with towncrier (consuming the `changelog.d/` fragments), and opens a `release/vX.Y.Z` PR against `main`
 
-4. Approver accepts the environment gate
+4. Review the PR — it shows exactly what will be released — then approve and merge it. **Merging is the deploy trigger**; close the PR instead if you are not ready to ship
 
-5. All components deploy to prod
+### Step 2 — Promotion (automatic)
 
-6. Tag created, GitHub Release published with changelog
+Merging the `release/*` PR automatically triggers "Promote to PROD" (it can also be run manually from the Actions tab as a fallback, e.g. to retry a failed run):
+
+1. Pre-flight checks run first: the `CHANGELOG.md` entry for the current version must exist (and the tag must not), and the Heroku production apps are verified (apps reachable, backend apps on the `container` stack, `DATABASE_URL` present)
+
+2. All components deploy to prod. If required reviewers are configured on the `prod-backend`/`prod-frontend` environments, the deploy jobs pause for approval — remove them in Settings → Environments for a fully automatic promotion
+
+3. Tag `vX.Y.Z` is created and the GitHub Release is published (Releases tab) with the changelog section from the merged release PR
 
 ## Versioning: CalVer
 
 Format: YYYY.MM.PATCH (e.g., 2026.04.1, 2026.04.2, 2026.05.1)
 
-The "Create Release Tag" workflow auto-calculates the next version. Within the same month, patch increments. New month resets to 1. You can override with a specific version.
+The "Prepare Release" workflow auto-calculates the next version from `version.py`. Within the same month, patch increments. New month resets to 1. You can override with a specific version via the `version_override` input.
 
 Tags are the source of truth for what's in production.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,0 +1,48 @@
+# Towncrier changelog configuration.
+# Lives at the repo root (not backend/pyproject.toml) so that
+# `uv run towncrier` finds it when invoked from the repo root,
+# where CHANGELOG.md and changelog.d/ live.
+[tool.towncrier]
+package = "version"
+package_dir = "."
+filename = "CHANGELOG.md"
+directory = "changelog.d"
+title_format = "## {version} ({project_date})"
+template = "changelog.d/_template.md.jinja2"
+# Markdown output: no rst-style title underlines
+underlines = ["", "", ""]
+
+[[tool.towncrier.type]]
+directory = "feature"
+name = "Features"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "fix"
+name = "Bug Fixes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "breaking"
+name = "Breaking Changes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "deprecation"
+name = "Deprecations"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "improvement"
+name = "Improvements"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "doc"
+name = "Documentation"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "misc"
+name = "Internal Changes"
+showcontent = false


### PR DESCRIPTION
<!-- CHANGELOG:START -->
### Changelog

**fix** (GSCHED-986): Fix the release process: changelog is now built in a reviewable release PR (Prepare Release workflow) instead of pushing to the protected main branch, promotion pre-flight verifies the Heroku app setup, and the GitHub Release is created via the API
<!-- CHANGELOG:END -->



## Scope

<!-- CI auto-detects this, but it helps reviewers to see at a glance. -->

- [ ] Backend (`backend/`)
- [ ] Frontend (`frontend/`)
- [ ] Docs (`docs/`)
- [x] CI/Infra (`.github/`)


<!-- 
  REQUIRED: Add a changelog fragment file to this PR.
  
  Quickest way (auto-detects ticket from branch name):
    ./scripts/changelog-fragment "Your change description"
    ./scripts/changelog-fragment "Your change description" fix
    ./scripts/changelog-fragment "" misc

  Manual:
    echo "Description" > changelog.d/GSCHED-190.feature.md

  Types: feature, fix, breaking, deprecation, improvement, doc, misc
  CI will fail if no fragment is found (unless only CI/docs files changed).
-->


## Jira

<!-- JIRA:START -->
[GSCHED-967](https://noirlab.atlassian.net/browse/GSCHED-967)
<!-- JIRA:END -->

## Checklist

- [ ] Changelog fragment added to `changelog.d/`
- [ ] Commit messages follow conventional commits (`feat(backend):`, `fix(frontend):`, etc.)
- [ ] No breaking changes (or `breaking` fragment added)
