### PR TITLE
GSCHED-994: fix(backend): Reorganize observation too_status section

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scheduler"
-version = "0.1.16"
+version = "0.1.17"
 description = "Gemini Observatory automated scheduler"
 readme = 'README.md'
 authors = [{ name = "NOIRLab" }]

--- a/backend/scheduler/core/programprovider/ocs/ocsprogramprovider.py
+++ b/backend/scheduler/core/programprovider/ocs/ocsprogramprovider.py
@@ -1114,6 +1114,19 @@ class OcsProgramProvider(ProgramProvider):
             # Check sequence for the pre-imaging flag
             preimaging = parse_preimaging(data[OcsProgramProvider._ObsKeys.SEQUENCE])
 
+            # If the ToO override rapid setting is in place, then the default too_type for the program
+            # is overridden, i.e. it is a Standard ToO
+            if prg_too_type == TooType.RAPID:
+                if (OcsProgramProvider._ObsKeys.TOO_OVERRIDE_RAPID in data and
+                        data[OcsProgramProvider._ObsKeys.TOO_OVERRIDE_RAPID]) :
+                    too_type = TooType.STANDARD
+                else:
+                    too_type = TooType.RAPID
+            elif prg_too_type == TooType.STANDARD:
+                too_type = TooType.STANDARD
+            else:
+                too_type = TooType.NONE
+                
             # TODO: Should this be a list of all targets for the observation?
             targets = []
 
@@ -1180,19 +1193,6 @@ class OcsProgramProvider(ProgramProvider):
                 for user_target_data in user_targets_data:
                     user_target = self.parse_target(user_target_data)
                     targets.append(user_target)
-
-                # If the ToO override rapid setting is in place, then the default too_type for the program
-                # is overridden, i.e. it is a Standard ToO
-                if prg_too_type == TooType.RAPID:
-                    if (OcsProgramProvider._ObsKeys.TOO_OVERRIDE_RAPID in data and
-                            data[OcsProgramProvider._ObsKeys.TOO_OVERRIDE_RAPID]) :
-                        too_type = TooType.STANDARD
-                    else:
-                        too_type = TooType.RAPID
-                elif prg_too_type == TooType.STANDARD:
-                    too_type = TooType.STANDARD
-                else:
-                    too_type = TooType.NONE
 
             return GeminiObservation(
                 id=ObservationID(obs_id),

--- a/changelog.d/GSCHED-994.fix.md
+++ b/changelog.d/GSCHED-994.fix.md
@@ -1,0 +1,1 @@
+Reorganize observation too_status section


### PR DESCRIPTION
Pull the too_status section out of the targets section in parse_observation since these are not connected. This ensures that too_status is always set.

## Scope

<!-- CI auto-detects this, but it helps reviewers to see at a glance. -->

- [ ] Backend (`backend/`)
- [ ] Frontend (`frontend/`)
- [ ] Docs (`docs/`)
- [ ] CI/Infra (`.github/`)


<!-- 
  REQUIRED: Add a changelog fragment file to this PR.
  
  Quickest way (auto-detects ticket from branch name):
    ./scripts/changelog-fragment "Your change description"
    ./scripts/changelog-fragment "Your change description" fix
    ./scripts/changelog-fragment "" misc

  Manual:
    echo "Description" > changelog.d/GSCHED-190.feature.md

  Types: feature, fix, breaking, deprecation, improvement, doc, misc
  CI will fail if no fragment is found (unless only CI/docs files changed).
-->


## Jira

<!-- JIRA:START -->
<!-- Auto-linked from branch name (e.g. GSCHED-190/description) by the PR Jira Link workflow. -->
<!-- JIRA:END -->

## Checklist

- [ ] Changelog fragment added to `changelog.d/`
- [ ] Commit messages follow conventional commits (`feat(backend):`, `fix(frontend):`, etc.)
- [ ] No breaking changes (or `breaking` fragment added)
