### PR TITLE
fix(backend): Fix placement of rToOs, update peak_score output

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scheduler"
-version = "0.1.17"
+version = "0.1.18"
 description = "Gemini Observatory automated scheduler"
 readme = 'README.md'
 authors = [{ name = "NOIRLab" }]

--- a/backend/scheduler/core/components/optimizer/greedymax.py
+++ b/backend/scheduler/core/components/optimizer/greedymax.py
@@ -419,8 +419,12 @@ class GreedyMaxOptimizer(BaseOptimizer):
 
         if len(max_group_info.interval) > 1:
             # Slide across the interval, integrating the score over the group length
-            for idx in range(max_group_info.interval[0],
-                             max_group_info.interval[-1] - max_group_info.n_slots_remaining + 2):
+            # If a rToO, then use the start of the interval, don't need to slide
+            if max_group_info.group_data.group.too_type() >= TooType.RAPID:
+                max_range = max_group_info.interval[0] + 1
+            else:
+                max_range = max_group_info.interval[-1] - max_group_info.n_slots_remaining + 2
+            for idx in range(max_group_info.interval[0], max_range):
 
                 integral_score = sum(scores[idx:idx + max_group_info.n_slots_remaining + 1])
 
@@ -1030,7 +1034,10 @@ class GreedyMaxOptimizer(BaseOptimizer):
         # Get visit score and store information for the output plans
         end_time_slot = start_time_slot + visit_length - 1
         visit_score = sum(max_group_info.group_data.group_info.scores[night_idx][start_time_slot:end_time_slot + 1])
-        peak_score = max(max_group_info.group_data.group_info.scores[night_idx][start_time_slot:end_time_slot + 1])
+        # Peak score where the group was placed
+        # peak_score = max(max_group_info.group_data.group_info.scores[night_idx][start_time_slot:end_time_slot + 1])
+        # Peak score that was used to pick the group for the plan
+        peak_score = max_group_info.max_score
 
         self.obs_in_plan[site][start_time_slot] = ObsPlanData(
             obs=obs,

--- a/changelog.d/GSCHED-988.fix.md
+++ b/changelog.d/GSCHED-988.fix.md
@@ -1,0 +1,1 @@
+Fix placement of rToOs so they are scheduled as soon as possible


### PR DESCRIPTION
Added missing code to stop the sliding score sum over the interval in greedymax._integrate_score for rToOs so that it will get placed as early in the night as possible.

Also, changed the peak_score in the output visits to be the max that greedymax uses to select the group for placement rather than the maximum score in the interval where is it finally placed.

## Scope

<!-- CI auto-detects this, but it helps reviewers to see at a glance. -->

- [ ] Backend (`backend/`)
- [ ] Frontend (`frontend/`)
- [ ] Docs (`docs/`)
- [ ] CI/Infra (`.github/`)


<!-- 
  REQUIRED: Add a changelog fragment file to this PR.
  
  Quickest way (auto-detects ticket from branch name):
    ./scripts/changelog-fragment "Your change description"
    ./scripts/changelog-fragment "Your change description" fix
    ./scripts/changelog-fragment "" misc

  Manual:
    echo "Description" > changelog.d/GSCHED-190.feature.md

  Types: feature, fix, breaking, deprecation, improvement, doc, misc
  CI will fail if no fragment is found (unless only CI/docs files changed).
-->


## Jira

<!-- JIRA:START -->
<!-- Auto-linked from branch name (e.g. GSCHED-190/description) by the PR Jira Link workflow. -->
<!-- JIRA:END -->

## Checklist

- [ ] Changelog fragment added to `changelog.d/`
- [ ] Commit messages follow conventional commits (`feat(backend):`, `fix(frontend):`, etc.)
- [ ] No breaking changes (or `breaking` fragment added)
