### PR TITLE
GSCHED-1007: Fix atoms stranded as observation is marked observed

### DIFF
--- a/backend/scheduler/core/components/collector/collector.py
+++ b/backend/scheduler/core/components/collector/collector.py
@@ -718,40 +718,34 @@ class Collector(SchedulerComponent):
                 # prog_obs = grpvisit.group.program_observations()
                 part_obs = grpvisit.group.partner_observations()
 
+                visit_observations: Dict[ObservationID, Observation] = {}
+                atoms_charged: Dict[ObservationID, int] = {}
+
                 for visit in grpvisit.visits:
                     # Observation information
                     observation = self.get_observation(visit.obs_id)
-
-                    # Number of slots in acquisition
-                    n_slots_acq = time2slots(time_slot_length, observation.acq_overhead)
+                    visit_observations.setdefault(observation.id, observation)
+                    atoms_charged.setdefault(observation.id, 0)
 
                     # Cumulative exec_times of unobserved atoms
                     cumul_seq = observation.cumulative_exec_times()
                     obs_seq = observation.sequence
 
-                    if charge_group:
-                        # Check if the Observation has been completely observed.
-                        if visit.atom_end_idx == len(obs_seq) - 1:
-                            _logger.debug(f'Marking observation complete: {observation.id.id}')
-                            observation.status = ObservationStatus.OBSERVED
-                            grpvisit.group.number_observed += 1
-                            if observation in part_obs:
-                                part_obs.remove(observation)
-                        else:
-                            _logger.debug(f'Marking observation ongoing: {observation.id.id}')
-                            observation.status = ObservationStatus.ONGOING
-
                     # Loop over atoms
                     for atom_idx in range(visit.atom_start_idx, visit.atom_end_idx + 1):
-                        # calculate end time slot for each atom and compare with end_timeslot_charge
-                        slot_length_visit = n_slots_acq + time2slots(time_slot_length, cumul_seq[atom_idx])  # noqa
+                        # Slots from the start of the visit through this atom.
+                        # These boundaries are the ones GreedyMax._length_visit used to size the visit.
+                        slot_length_visit = time2slots(time_slot_length,
+                                                       observation.acq_overhead + cumul_seq[atom_idx])  # noqa
                         slot_atom_end = visit.start_time_slot + slot_length_visit - 1
 
                         if atom_idx == visit.atom_start_idx:
                             slot_atom_length = slot_length_visit
                         else:
-                            time_slots = time2slots(time_slot_length, cumul_seq[atom_idx-1])  # noqa
-                            slot_atom_length = slot_length_visit - n_slots_acq - time_slots
+                            prev_slot_length_visit = time2slots(time_slot_length,
+                                                                observation.acq_overhead
+                                                                + cumul_seq[atom_idx - 1])  # noqa
+                            slot_atom_length = slot_length_visit - prev_slot_length_visit
                         if slot_atom_length > 0:
                             slot_atom_start = slot_atom_end - slot_atom_length + 1
                         else:
@@ -782,6 +776,7 @@ class Collector(SchedulerComponent):
                                 obs_seq[atom_idx].qa_state = QAState.PASS
 
                                 atom_record.observed = True
+                                atoms_charged[observation.id] += 1
 
                             elif not_charged:
                                 # charge to not_charged
@@ -792,8 +787,29 @@ class Collector(SchedulerComponent):
                                 obs_seq[atom_idx].not_charged += not_charged_time
                                 atom_record.not_charged += not_charged_time
 
-                # If charging the groups, set remaining partner cals to INACTIVE
                 if charge_group:
+                    # Set the status from what was executed, not from what was planned. An
+                    # observation with any atom left unobserved must not be marked OBSERVED:
+                    # the Selector skips OBSERVED observations, so doing so would strand its
+                    # remaining atoms for the rest of the run.
+                    for observation in visit_observations.values():
+                        if atoms_charged[observation.id] == 0:
+                            # The bound fell before any atom of this visit could finish, so
+                            # nothing was executed and the status is not ours to change.
+                            _logger.debug(f'No atoms charged for {observation.id.id}: '
+                                          f'leaving status {observation.status.name}.')
+                        elif all(atom.observed for atom in observation.sequence):
+                            _logger.debug(f'Marking observation complete: {observation.id.id}')
+                            if observation.status != ObservationStatus.OBSERVED:
+                                grpvisit.group.number_observed += 1
+                            observation.status = ObservationStatus.OBSERVED
+                            if observation in part_obs:
+                                part_obs.remove(observation)
+                        else:
+                            _logger.debug(f'Marking observation ongoing: {observation.id.id}')
+                            observation.status = ObservationStatus.ONGOING
+
+                    # Set remaining partner cals to INACTIVE
                     for obs in part_obs:
                         _logger.debug(f'\tTime_accounting setting {obs.unique_id.id} to INACTIVE.')
                         obs.status = ObservationStatus.INACTIVE

--- a/backend/scheduler/core/components/collector/collector.py
+++ b/backend/scheduler/core/components/collector/collector.py
@@ -696,11 +696,18 @@ class Collector(SchedulerComponent):
                     # For now, only charge a scheduling group if it can be done fully
                     charge_group = end_timeslot_bound is None or end_timeslot_bound > grpvisit.end_time_slot()
                 else:
-                    observation = self.get_observation(grpvisit.visits[0].obs_id)
-                    n_slots_acq = time2slots(time_slot_length, observation.acq_overhead)
-                    # This should probably be the first unobserved atom, not the first in the sequence.
-                    n_slots_atom0 = time2slots(time_slot_length, observation.sequence[0].exec_time)
-                    slot_atom0_end = grpvisit.visits[0].start_time_slot + n_slots_atom0 - 1 + n_slots_acq
+                    # A non-scheduling group holds exactly one visit. Measure the atom that visit
+                    # will actually run: an observation resumed from an earlier night starts partway
+                    # into the sequence, and its leading atoms will not be repeated. Converting once,
+                    # from atom_start_idx, makes this the same expression the atom loop applies to
+                    # that atom, so the gate is exactly "its first atom finished before the bound".
+                    first_visit = grpvisit.visits[0]
+                    observation = self.get_observation(first_visit.obs_id)
+                    cumul_seq = observation.cumulative_exec_times()
+                    n_slots_atom0 = time2slots(time_slot_length,
+                                               observation.acq_overhead
+                                               + cumul_seq[first_visit.atom_start_idx])  # noqa
+                    slot_atom0_end = first_visit.start_time_slot + n_slots_atom0 - 1
                     charge_group = end_timeslot_bound is None or end_timeslot_bound > slot_atom0_end
 
                 # Charge if the end slot is less than this
@@ -787,10 +794,12 @@ class Collector(SchedulerComponent):
                                 obs_seq[atom_idx].not_charged += not_charged_time
                                 atom_record.not_charged += not_charged_time
 
+                    visit.completion = f'{sum(1 for atom in obs_seq if atom.observed)}/{len(obs_seq)}'
+
                 if charge_group:
                     # Set the status from what was executed, not from what was planned. An
                     # observation with any atom left unobserved must not be marked OBSERVED:
-                    # the Selector skips OBSERVED observations, so doing so would strand its
+                    # the Selector skips OBSERVED observations, so doing would strand its
                     # remaining atoms for the rest of the run.
                     for observation in visit_observations.values():
                         if atoms_charged[observation.id] == 0:

--- a/backend/scheduler/core/plans/plan.py
+++ b/backend/scheduler/core/plans/plan.py
@@ -121,6 +121,8 @@ class Plan:
             obs.fpu(),
             obs.disperser(),
             obs.filters(),
+            # Completion as planned. Collector.time_accounting restates this from the atoms that
+            # were actually observed, since an event can cut the visit short of atom_end.
             f"{atom_end + 1}/{len(obs.sequence)}",
         )
         self.visits.append(visit)

--- a/backend/tests/unit/scheduler/core/collector/test_time_accounting.py
+++ b/backend/tests/unit/scheduler/core/collector/test_time_accounting.py
@@ -1,0 +1,335 @@
+# Copyright (c) 2016-2026 Association of Universities for Research in Astronomy, Inc. (AURA)
+# For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+"""
+Time accounting of interrupted (partial) observations.
+
+An event -- a weather closure or a fault -- can cut a visit short. The atoms that did not
+finish must not be charged, and the observation must not be marked OBSERVED: the Selector
+skips OBSERVED observations, so marking one prematurely loses its remaining atoms forever.
+"""
+
+from datetime import datetime, timedelta
+from typing import List, Optional, Sequence, Tuple
+
+import astropy.units as u
+import pytest
+from astropy.time import TimeDelta
+from lucupy.minimodel import (AndOption, Atom, GROUP_NONE_ID, Group, GroupID, NightIndex, Observation,
+                              ObservationClass, ObservationID, ObservationMode, ObservationStatus, Priority, Program,
+                              ProgramID, ProgramMode, ProgramTypes, QAState, ROOT_GROUP_ID, SetupTimeType, Site)
+from lucupy.types import ZeroTime
+
+from scheduler.core.components.collector import Collector
+from scheduler.core.plans import Plan, Plans, Visit
+from scheduler.time_accountant import TimeAccountant
+
+_SITE = Site.GN
+_NIGHT_IDX = NightIndex(0)
+_PROGRAM_ID = ProgramID('GN-2018B-Q-101')
+_START = datetime(2018, 10, 1, 20, 0, 0)
+
+
+# The Collector ClassVars are global state shared with the (module-scoped) collector fixtures
+# in conftest, so they are swapped out through monkeypatch rather than assigned directly.
+@pytest.fixture(autouse=True)
+def _isolated_collector_tables(monkeypatch):
+    monkeypatch.setattr(Collector, '_observations', {}, raising=False)
+    monkeypatch.setattr(Collector, '_programs', {}, raising=False)
+
+
+def _collector(slot_minutes: float = 1.0) -> Collector:
+    """A Collector holding only what time_accounting reads.
+
+    __post_init__ builds night events and loads resource files; time_accounting touches
+    none of that, so it is bypassed.
+    """
+    collector = Collector.__new__(Collector)
+    collector.time_slot_length = TimeDelta(slot_minutes * u.min)
+    collector.time_accountant = TimeAccountant(frozenset({_SITE}), [_NIGHT_IDX])
+    return collector
+
+
+def _atom(atom_id: int, exec_seconds: int, obs_class: ObservationClass, observed: bool = False) -> Atom:
+    exec_time = timedelta(seconds=exec_seconds)
+    is_partner = obs_class == ObservationClass.PARTNERCAL
+    return Atom(id=atom_id,
+                exec_time=exec_time,
+                prog_time=ZeroTime if is_partner else exec_time,
+                part_time=exec_time if is_partner else ZeroTime,
+                program_used=ZeroTime,
+                partner_used=ZeroTime,
+                not_charged=ZeroTime,
+                observed=observed,
+                qa_state=QAState.PASS if observed else QAState.NONE,
+                guide_state=True,
+                resources=frozenset(),
+                wavelengths=frozenset(),
+                obs_mode=ObservationMode.IMAGING)
+
+
+def _observation(obs_id: str,
+                 acq_seconds: int,
+                 atom_specs: Sequence[Tuple[int, bool]],
+                 obs_class: ObservationClass = ObservationClass.SCIENCE,
+                 status: ObservationStatus = ObservationStatus.READY) -> Observation:
+    """atom_specs is a sequence of (exec_seconds, already_observed) pairs."""
+    return Observation(id=ObservationID(obs_id),
+                       internal_id=obs_id,
+                       order=0,
+                       title=obs_id,
+                       site=_SITE,
+                       status=status,
+                       active=True,
+                       priority=Priority.MEDIUM,
+                       setuptime_type=SetupTimeType.FULL,
+                       acq_overhead=timedelta(seconds=acq_seconds),
+                       obs_class=obs_class,
+                       targets=[],
+                       guiding={},
+                       sequence=[_atom(idx, secs, obs_class, observed)
+                                 for idx, (secs, observed) in enumerate(atom_specs)],
+                       belongs_to=_PROGRAM_ID,
+                       constraints=None)
+
+
+def _group(group_id: GroupID, children, number_to_observe: int) -> Group:
+    return Group(id=group_id,
+                 program_id=_PROGRAM_ID,
+                 group_name=group_id.id,
+                 parent_id=ROOT_GROUP_ID,
+                 previous_id=GROUP_NONE_ID,
+                 next_id=GROUP_NONE_ID,
+                 number_to_observe=number_to_observe,
+                 number_observed=0,
+                 delay_min=ZeroTime,
+                 delay_max=ZeroTime,
+                 active=True,
+                 children=children,
+                 group_option=AndOption.CONSEC_ORDERED)
+
+
+def _observation_group(obs: Observation) -> Group:
+    """The trivial AND group wrapping a single observation, as the program providers build it."""
+    return _group(GroupID(obs.id.id), obs, 1)
+
+
+def _register(observations: List[Observation], scheduling_group: bool = False) -> List[Group]:
+    """Populate the Collector tables and return the top-level groups, in root order."""
+    obs_groups = [_observation_group(obs) for obs in observations]
+    if scheduling_group:
+        top_level = [_group(GroupID('sched'), obs_groups, len(obs_groups))]
+    else:
+        top_level = obs_groups
+
+    root = _group(ROOT_GROUP_ID, top_level, len(top_level))
+    Collector._programs[_PROGRAM_ID] = Program(id=_PROGRAM_ID,
+                                               internal_id=_PROGRAM_ID.id,
+                                               semester=None,
+                                               thesis=False,
+                                               mode=ProgramMode.QUEUE,
+                                               type=ProgramTypes.Q,
+                                               start=_START,
+                                               end=_START + timedelta(days=180),
+                                               allocated_time=frozenset(),
+                                               used_time=frozenset(),
+                                               root_group=root)
+    for obs in observations:
+        Collector._observations[obs.id] = (obs, None)
+    return top_level
+
+
+def _visit(obs: Observation,
+           atom_start: int,
+           atom_end: int,
+           start_time_slot: int,
+           time_slots: int) -> Visit:
+    return Visit(start_time=_START,
+                 obs_id=obs.id,
+                 obs_class=obs.obs_class,
+                 obs_conditions=None,
+                 atom_start_idx=atom_start,
+                 atom_end_idx=atom_end,
+                 start_time_slot=start_time_slot,
+                 time_slots=time_slots,
+                 score=1.0,
+                 peak_score=1.0,
+                 step_start_idx=None,
+                 step_count=None,
+                 instrument=None,
+                 fpu=None,
+                 disperser=None,
+                 filters=None,
+                 completion=f'{atom_end + 1}/{len(obs.sequence)}')
+
+
+def _plans(visits: List[Visit], slot_minutes: float = 1.0) -> Plans:
+    plans = Plans(night_events={}, night_conditions={}, night_idx=_NIGHT_IDX)
+    plan = Plan(start=_START,
+                end=_START + timedelta(hours=10),
+                time_slot_length=timedelta(minutes=slot_minutes),
+                site=_SITE,
+                _time_slots_left=600,
+                conditions=None)
+    plan.visits = list(visits)
+    plans[_SITE] = plan
+    return plans
+
+
+def _account(collector: Collector, plans: Plans, bound: Optional[int] = None) -> None:
+    end_timeslot_bounds = None if bound is None else {_SITE: bound}
+    collector.time_accounting(plans=plans,
+                              sites=frozenset({_SITE}),
+                              end_timeslot_bounds=end_timeslot_bounds)
+
+
+def test_truncated_visit_leaves_observation_ongoing():
+    """An event at slot 12 cuts a 3-atom visit after its second atom.
+
+    acq=2min + atoms of 5min each, so the atoms end at slots 6, 11 and 16. The last atom
+    never ran, so the observation must stay schedulable.
+    """
+    obs = _observation('GN-2018B-Q-101-1', acq_seconds=120, atom_specs=[(300, False)] * 3)
+    group = _register([obs])[0]
+    collector = _collector()
+
+    _account(collector, _plans([_visit(obs, 0, 2, start_time_slot=0, time_slots=17)]), bound=12)
+
+    assert [atom.observed for atom in obs.sequence] == [True, True, False]
+    assert obs.status is ObservationStatus.ONGOING
+    assert group.number_observed == 0
+
+
+def test_full_night_marks_observation_observed():
+    """Whole-night accounting is unchanged: everything ran, so the observation completes."""
+    obs = _observation('GN-2018B-Q-101-1', acq_seconds=120, atom_specs=[(300, False)] * 3)
+    group = _register([obs])[0]
+    collector = _collector()
+
+    _account(collector, _plans([_visit(obs, 0, 2, start_time_slot=0, time_slots=17)]))
+
+    assert all(atom.observed for atom in obs.sequence)
+    assert obs.status is ObservationStatus.OBSERVED
+    assert group.number_observed == 1
+    # The acquisition overhead is charged to the first atom.
+    assert obs.sequence[0].program_used == timedelta(seconds=300 + 120)
+
+
+def test_truncated_partner_cal_is_inactivated_not_observed():
+    """A partly-executed standard is still swept to INACTIVE, not reported as OBSERVED.
+
+    The 'we only needed one standard' semantics of the INACTIVE sweep are deliberately
+    kept; what must not happen is the observation being recorded as fully observed.
+    """
+    obs = _observation('GN-2018B-Q-101-2', acq_seconds=120, atom_specs=[(300, False)] * 3,
+                       obs_class=ObservationClass.PARTNERCAL)
+    group = _register([obs])[0]
+    collector = _collector()
+
+    _account(collector, _plans([_visit(obs, 0, 2, start_time_slot=0, time_slots=17)]), bound=12)
+
+    assert obs.status is ObservationStatus.INACTIVE
+    assert obs.sequence[2].observed is False
+    assert group.number_observed == 0
+
+
+def test_charge_group_with_no_charged_atoms_leaves_status_untouched():
+    """Nothing ran tonight, so the status is not time accounting's to change.
+
+    The observation resumes at atom 1 after a short (1 min) atom 0 observed on an earlier
+    night. charge_group is True only because collector.py:702 measures sequence[0] rather
+    than the first *unobserved* atom (a separate, still-open TODO), but the bound at slot 5
+    precedes atom 1's end at slot 11, so nothing is charged.
+    """
+    obs = _observation('GN-2018B-Q-101-1',
+                       acq_seconds=120,
+                       atom_specs=[(60, True), (600, False), (600, False)],
+                       status=ObservationStatus.ONGOING)
+    group = _register([obs])[0]
+    collector = _collector()
+
+    _account(collector, _plans([_visit(obs, 1, 2, start_time_slot=0, time_slots=22)]), bound=5)
+
+    assert [atom.observed for atom in obs.sequence] == [True, False, False]
+    assert obs.status is ObservationStatus.ONGOING
+    assert group.number_observed == 0
+
+
+def test_fractional_acquisition_charges_last_atom_on_full_night():
+    """A 90s acquisition must not cost the visit its final atom.
+
+    Converting the acquisition and the sequence separately takes two ceilings,
+    ceil(90s) + ceil(150s) = 2 + 3 = 5 slots, where GreedyMax sized the visit as a single
+    ceil(90s + 150s) = 4 slots. Under the two-ceiling form the last atom ends outside its
+    own visit and falls past the charge window on a full, uninterrupted night.
+    """
+    obs = _observation('GN-2018B-Q-101-1', acq_seconds=90, atom_specs=[(75, False)] * 2)
+    group = _register([obs])[0]
+    collector = _collector()
+
+    _account(collector, _plans([_visit(obs, 0, 1, start_time_slot=0, time_slots=4)]))
+
+    assert all(atom.observed for atom in obs.sequence)
+    assert obs.status is ObservationStatus.OBSERVED
+    assert group.number_observed == 1
+
+
+def test_interrupted_scheduling_group_is_not_charged():
+    """A scheduling group cut short is charged to not_charged, and no status is touched."""
+    obs_a = _observation('GN-2018B-Q-101-1', acq_seconds=120, atom_specs=[(300, False)] * 2)
+    obs_b = _observation('GN-2018B-Q-101-2', acq_seconds=120, atom_specs=[(300, False)] * 2)
+    _register([obs_a, obs_b], scheduling_group=True)
+    collector = _collector()
+
+    plans = _plans([_visit(obs_a, 0, 1, start_time_slot=0, time_slots=12),
+                    _visit(obs_b, 0, 1, start_time_slot=12, time_slots=12)])
+    _account(collector, plans, bound=18)
+
+    for obs in (obs_a, obs_b):
+        assert obs.status is ObservationStatus.READY
+        assert all(atom.program_used == ZeroTime for atom in obs.sequence)
+        assert all(not atom.observed for atom in obs.sequence)
+    # The group ran into the bound, so the time it consumed is not charged to the program.
+    assert obs_a.not_charged() > ZeroTime
+
+
+def test_two_visits_of_one_observation_in_a_night_charge_both():
+    """An observation continued later the same night is charged for both of its visits.
+
+    The two visits land in separate GroupVisits -- consecutive visits are merged only for
+    scheduling groups -- so they are accounted in turn: the first leaves the observation
+    ONGOING, the second completes it. Each visit pays its own acquisition overhead.
+    """
+    obs = _observation('GN-2018B-Q-101-1', acq_seconds=120, atom_specs=[(300, False)] * 3)
+    group = _register([obs])[0]
+    collector = _collector()
+
+    _account(collector, _plans([_visit(obs, 0, 1, start_time_slot=0, time_slots=12),
+                                _visit(obs, 2, 2, start_time_slot=12, time_slots=7)]))
+
+    assert all(atom.observed for atom in obs.sequence)
+    # Acquisition is charged to the first atom of each visit, so atoms 0 and 2 carry it.
+    assert [atom.program_used for atom in obs.sequence] == [timedelta(seconds=420),
+                                                            timedelta(seconds=300),
+                                                            timedelta(seconds=420)]
+    assert obs.status is ObservationStatus.OBSERVED
+    # Two visits, but one observation completed.
+    assert group.number_observed == 1
+
+
+def test_second_pass_completes_interrupted_observation():
+    """The atoms left behind by an interruption are charged and complete the observation."""
+    obs = _observation('GN-2018B-Q-101-1', acq_seconds=120, atom_specs=[(300, False)] * 3)
+    group = _register([obs])[0]
+    collector = _collector()
+
+    _account(collector, _plans([_visit(obs, 0, 2, start_time_slot=0, time_slots=17)]), bound=12)
+    assert obs.status is ObservationStatus.ONGOING
+    assert group.number_observed == 0
+
+    # Replan: the observation resumes at its first unobserved atom and runs to the end.
+    _account(collector, _plans([_visit(obs, 2, 2, start_time_slot=0, time_slots=7)]))
+
+    assert all(atom.observed for atom in obs.sequence)
+    assert obs.status is ObservationStatus.OBSERVED
+    assert group.number_observed == 1

--- a/changelog.d/GSCHED-1007.fix.md
+++ b/changelog.d/GSCHED-1007.fix.md
@@ -1,0 +1,1 @@
+Fix observations interrupted by a weather closure or fault being marked as fully observed, which stopped their remaining atoms from ever being rescheduled

--- a/changelog.d/GSCHED-1007.fix.md
+++ b/changelog.d/GSCHED-1007.fix.md
@@ -1,1 +1,1 @@
-Fix observations interrupted by a weather closure or fault being marked as fully observed, which stopped their remaining atoms from ever being rescheduled
+Fix observations interrupted by a weather closure or fault being marked as fully observed, which stopped their remaining atoms from ever being rescheduled, and report the completion of an interrupted visit as the atoms it actually observed rather than the atoms it was planned to reach


### PR DESCRIPTION
<!-- CHANGELOG:START -->
### Changelog

**fix** (GSCHED-1007): Fix observations interrupted by a weather closure or fault being marked as fully observed, which stopped their remaining atoms from ever being rescheduled, and report the completion of an interrupted visit as the atoms it actually observed rather than the atoms it was planned to reach
<!-- CHANGELOG:END -->

## Scope

<!-- CI auto-detects this, but it helps reviewers to see at a glance. -->

- [x] Backend (`backend/`)
- [ ] Frontend (`frontend/`)
- [ ] Docs (`docs/`)
- [ ] CI/Infra (`.github/`)


<!-- 
  REQUIRED: Add a changelog fragment file to this PR.
  
  Quickest way (auto-detects ticket from branch name):
    ./scripts/changelog-fragment "Your change description"
    ./scripts/changelog-fragment "Your change description" fix
    ./scripts/changelog-fragment "" misc

  Manual:
    echo "Description" > changelog.d/GSCHED-190.feature.md

  Types: feature, fix, breaking, deprecation, improvement, doc, misc
  CI will fail if no fragment is found (unless only CI/docs files changed).
-->


## Jira

<!-- JIRA:START -->
[GSCHED-1007](https://noirlab.atlassian.net/browse/GSCHED-1007)
<!-- JIRA:END -->

## Checklist

- [x] Changelog fragment added to `changelog.d/`
- [ ] Commit messages follow conventional commits (`feat(backend):`, `fix(frontend):`, etc.)
- [ ] No breaking changes (or `breaking` fragment added)
