### PR TITLE
Gsched 1000/fix missing toos after activation

### DIFF
--- a/backend/scheduler/core/components/collector/collector.py
+++ b/backend/scheduler/core/components/collector/collector.py
@@ -15,7 +15,7 @@ from astropy.time import Time, TimeDelta
 from lucupy.minimodel import (ALL_SITES, NightIndex, NightIndices,
                               Observation, ObservationID, ObservationClass, Program, ProgramID, ProgramTypes, Semester,
                               Site, Target, TimeslotIndex, QAState, ObservationStatus,
-                              Group, ResourceType)
+                              Group, ResourceType, TooType)
 from lucupy.timeutils import time2slots
 from lucupy.types import Day, ZeroTime
 
@@ -457,8 +457,13 @@ class Collector(SchedulerComponent):
                     continue
 
                 # Is the program excluded on a given night due to block scheduling
+                # A rapid ToO can be triggered on any night, including one where its program is
+                # blocked, so block scheduling must not drop it from the visibility calculation:
+                # without TargetInfo the Selector cannot schedule it once it is activated. The
+                # Selector re-applies the night filter, and the rapid override, per night.
                 prog= self.get_program(p_id)
-                can_schedule = nc[obs.site][night_idx].filter.program_filter(prog)
+                can_schedule = (obs.too_type is TooType.RAPID
+                                or nc[obs.site][night_idx].filter.program_filter(prog))
                 if not can_schedule:
                     continue
 
@@ -592,7 +597,10 @@ class Collector(SchedulerComponent):
                     )
                 if not has_resources:
                     continue
-                if not nc[obs.site][night_idx].filter.program_filter(self.get_program(p_id)):
+                # Rapid ToOs bypass block scheduling here so that they always have visibility
+                # data available for activation. See the note in load_programs.
+                if (obs.too_type is not TooType.RAPID
+                        and not nc[obs.site][night_idx].filter.program_filter(self.get_program(p_id))):
                     continue
                 obs_with_resources[night_idx].append(obs)
 

--- a/backend/scheduler/core/components/selector/selector.py
+++ b/backend/scheduler/core/components/selector/selector.py
@@ -470,15 +470,26 @@ class Selector(SchedulerComponent):
         mrc = obs.constraints.conditions
         is_splittable = len(obs.sequence) > 1
 
+        # An activated rapid ToO overrides program-level block scheduling (partner, PV and classical
+        # blocks): in operations a rapid trigger interrupts whoever's block the night belongs to.
+        # Standard ToOs stay tied to their program's calendar filter. The override only applies on
+        # nights that accept ToOs (too_status is also False on closed / engineering nights), and the
+        # group filter, which carries resource availability, still applies below.
+        is_activated_rapid_too = (obs.too_type is TooType.RAPID
+                                  and obs.status in {ObservationStatus.READY, ObservationStatus.ONGOING})
+
         # Calculate a numpy array of bool indexed by night to determine when the group can be added to the plan
         # based on the night configuration filtering.
         # TODO: We also filter on program here, but this would be better done in score_program.
         # TODO: That would require some thought as to how to do this there given the structure of a Selection.
         night_filtering: Dict[NightIndex, bool] = {}
         for night_idx in obs_nights:
-            night_filter = night_configurations[obs.site][night_idx].filter
+            night_configuration = night_configurations[obs.site][night_idx]
+            night_filter = night_configuration.filter
+            program_filtering = (night_filter.program_filter(program)
+                                 or (is_activated_rapid_too and night_configuration.too_status))
             # NOTE: to only do group filtering, comment out the first line and use the second line.
-            night_filtering[night_idx] = night_filter.program_filter(program) and night_filter.group_filter(group)
+            night_filtering[night_idx] = program_filtering and night_filter.group_filter(group)
             # night_filtering[night_idx] = night_filter.group_filter(group)
 
         if obs.obs_class in [ObservationClass.SCIENCE, ObservationClass.PROGCAL]:

--- a/backend/scheduler/services/resource/file_based_resource_service.py
+++ b/backend/scheduler/services/resource/file_based_resource_service.py
@@ -6,7 +6,7 @@ import re
 from copy import copy
 from datetime import date, datetime, time, timedelta
 from io import BytesIO, StringIO
-from typing import Callable, Dict, Final, List, Optional, Set, Type, TypeVar, Union
+from typing import Callable, Dict, Final, List, Optional, Set, Tuple, Type, TypeVar, Union
 
 from astropy.time import Time
 from openpyxl.reader.excel import load_workbook
@@ -590,60 +590,59 @@ class FileBasedResourceService(ResourceService):
         except FileNotFoundError:
             logger.error(f'Faults file not available: {path}')
 
+    @staticmethod
+    def _twilights(site: Site, night_date: date) -> Tuple[datetime, datetime]:
+        """
+        The local 12 degree evening and morning twilights of the night that starts on night_date.
+        """
+
+        #The query is anchored at 14:00 local.
+        # The anchor has to be timezone-aware, otherwise the night returned depends on
+        # the timezone of the machine running the service.
+        anchor = Time(datetime.combine(night_date, time(hour=14), tzinfo=site.timezone))
+        eve_twi, morn_twi = night_events(anchor, site.location, site.timezone)[3:5]
+        return eve_twi.to_datetime(site.timezone), morn_twi.to_datetime(site.timezone)
+
     def _load_toos(self, site: Site, name: str) -> None:
         """
-        Load the too activations from the specified .txt file.
+        Load the ToOs activations from the specified .txt file.
         """
         path = self._subdir / name
         try:
             with open(path, 'r') as input_file:
                 too_activations = self._too_activations[site]
                 for line in input_file:
-                    if line.strip()[0] != '#':  # ignore lines that are commented out
-                        too_id, too_date, too_time = line.split()
+                    # ignore blank lines and lines that are commented out
+                    if not line.strip() or line.strip()[0] == '#':
+                        continue
 
-                        # UTC dates
-                        too_date_str = too_date+' '+too_time.rstrip('\n')+' +0000'
-                        too_datetime = datetime.strptime(too_date_str, '%Y-%m-%d %H:%M:%S.%f %z')
+                    too_id, too_date, too_time = line.split()
 
-                        local_datetime = too_datetime.astimezone(site.timezone)
+                    # UTC dates
+                    too_date_str = too_date+' '+too_time.rstrip('\n')+' +0000'
+                    too_datetime = datetime.strptime(too_date_str, '%Y-%m-%d %H:%M:%S.%f %z')
+                    local_datetime = too_datetime.astimezone(site.timezone)
+
+                    if local_datetime.time() < FileBasedResourceService._noon:
+                        local_night_date = local_datetime.date() - FileBasedResourceService._day
+                    else:
                         local_night_date = local_datetime.date()
+                    eve_twi, morn_twi = FileBasedResourceService._twilights(site, local_night_date)
 
-                        # Twilight for events happening before or after
-                        new_ut_time = time(14, 0)
-                        astropy_time = Time(
-                            datetime.combine(local_night_date, new_ut_time).astimezone(
-                                site.timezone))
+                    if local_datetime > morn_twi:
+                        # Triggered in the morning after that night ended: it belongs to the next night.
+                        local_night_date = local_datetime.date()
+                        eve_twi, morn_twi = FileBasedResourceService._twilights(site, local_night_date)
 
-                        # Get the twilights and localize them.
-                        eve_twi, morn_twi = night_events(astropy_time, site.location, site.timezone)[3:5]
-                        eve_twi = eve_twi.to_datetime(site.timezone)
-                        morn_twi = morn_twi.to_datetime(site.timezone)
+                    if local_datetime < eve_twi:
+                        # Triggered before the night started, so activate once it does.
+                        local_datetime = eve_twi + timedelta(seconds=25)  # small offset
 
-                        if eve_twi > local_datetime:
-                            # belong to that day but is before the eve twi
-                            local_datetime = eve_twi + timedelta(seconds=25) # small offset
+                    too_activation = ToOActivation(site=site,
+                                                   too_id=ObservationID(too_id),
+                                                   start_time=local_datetime)
 
-                        if morn_twi < local_datetime:
-                            # belongs to the next day after the eve twi
-                            next_eve_twi, next_morn_twi = night_events(astropy_time + timedelta(days=1), site.location, site.timezone)[3:5]
-                            next_eve_twi = next_eve_twi.to_datetime(site.timezone)
-
-                            if next_eve_twi > local_datetime:
-                                local_datetime = next_eve_twi + timedelta(seconds=25)  # small offset
-
-                        if local_datetime < morn_twi and site == Site.GN:
-                            # belongs to day before but it happens after midnight.
-                            local_night_date = local_datetime.date() - timedelta(days=1)
-                        else:
-                            local_night_date = local_datetime.date()
-                        too_activations.setdefault(local_night_date, set())
-
-                        too_activation = ToOActivation(site=site,
-                                                       too_id=ObservationID(too_id),
-                                                       start_time=local_datetime)
-
-                        too_activations[local_night_date].add(too_activation)
+                    too_activations.setdefault(local_night_date, set()).add(too_activation)
 
         except FileNotFoundError:
             logger.error(f'Too Activation file not available: {path}')

--- a/changelog.d/GSCHED-1000.fix.md
+++ b/changelog.d/GSCHED-1000.fix.md
@@ -1,0 +1,1 @@
+Modify the filter that was blocking Rapid ToOs when the program type was not matching the calendar program filter. Also a few GS ToOs were being activated iun the wrong date when past the noon for UTC. 


### PR DESCRIPTION
<!-- CHANGELOG:START -->
### Changelog

**fix** (GSCHED-1000): Modify the filter that was blocking Rapid ToOs when the program type was not matching the calendar program filter. Also a few GS ToOs were being activated iun the wrong date when past the noon for UTC.
<!-- CHANGELOG:END -->

## Scope

<!-- CI auto-detects this, but it helps reviewers to see at a glance. -->

- [x] Backend (`backend/`)
- [ ] Frontend (`frontend/`)
- [ ] Docs (`docs/`)
- [ ] CI/Infra (`.github/`)


<!-- 
  REQUIRED: Add a changelog fragment file to this PR.
  
  Quickest way (auto-detects ticket from branch name):
    ./scripts/changelog-fragment "Your change description"
    ./scripts/changelog-fragment "Your change description" fix
    ./scripts/changelog-fragment "" misc

  Manual:
    echo "Description" > changelog.d/GSCHED-190.feature.md

  Types: feature, fix, breaking, deprecation, improvement, doc, misc
  CI will fail if no fragment is found (unless only CI/docs files changed).
-->


## Jira

<!-- JIRA:START -->
[GSCHED-1000](https://noirlab.atlassian.net/browse/GSCHED-1000)
<!-- JIRA:END -->

## Checklist

- [x] Changelog fragment added to `changelog.d/`
- [ ] Commit messages follow conventional commits (`feat(backend):`, `fix(frontend):`, etc.)
- [ ] No breaking changes (or `breaking` fragment added)
