### PR TITLE
Gsched-1010/Resource subscription issue on NightMonitor

### DIFF
--- a/backend/scheduler/night_monitor/event_sources.py
+++ b/backend/scheduler/night_monitor/event_sources.py
@@ -39,8 +39,13 @@ class ResourceEventSource(EventSource):
         return
 
     def subscriptions(self) -> List[Tuple[str ,callable]]:
-        return[
-            (ResourceEventSource.RESOURCE_EDIT, lambda x: self._client.subscribe(ResourceEventSource.RESOURCE_EDIT), None)
+        # No subscriptions yet!
+        return [
+            # (
+            #     ResourceEventSource.RESOURCE_EDIT,
+            #     lambda x: self._client.subscribe(ResourceEventSource.RESOURCE_EDIT),
+            #     None
+            # )
         ]
 
 class WeatherEventSource(EventSource):


### PR DESCRIPTION

## Scope

<!-- CI auto-detects this, but it helps reviewers to see at a glance. -->

- [x] Backend (`backend/`)
- [ ] Frontend (`frontend/`)
- [ ] Docs (`docs/`)
- [ ] CI/Infra (`.github/`)


<!-- 
  REQUIRED: Add a changelog fragment file to this PR.
  
  Quickest way (auto-detects ticket from branch name):
    ./scripts/changelog-fragment "Your change description"
    ./scripts/changelog-fragment "Your change description" fix
    ./scripts/changelog-fragment "" misc

  Manual:
    echo "Description" > changelog.d/GSCHED-190.feature.md

  Types: feature, fix, breaking, deprecation, improvement, doc, misc
  CI will fail if no fragment is found (unless only CI/docs files changed).
-->


## Jira

<!-- JIRA:START -->
[GSCHED-1010](https://noirlab.atlassian.net/browse/GSCHED-1010)
<!-- JIRA:END -->

## Checklist

- [ ] Changelog fragment added to `changelog.d/`
- [ ] Commit messages follow conventional commits (`feat(backend):`, `fix(frontend):`, etc.)
- [ ] No breaking changes (or `breaking` fragment added)
