### PR TITLE
feat(backend): Improve setting Band for GPP calibrations

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scheduler"
-version = "0.1.20"
+version = "0.1.21"
 description = "Gemini Observatory automated scheduler"
 readme = 'README.md'
 authors = [{ name = "NOIRLab" }]
@@ -47,7 +47,7 @@ dependencies = [
 [dependency-groups]
 gpp-prod = ["gpp-client>=26.7.1"]
 # Dev tracks the latest .dev release; When new cycle starts, bump the CalVer
-gpp-dev = ["gpp-client>=26.7.3.dev6,==26.7.3.*,!=26.7.3"]
+gpp-dev = ["gpp-client>=26.7.3.dev7,==26.7.3.*,!=26.7.3"]
 dev = [
     "hypothesis>=6.137.1",
     "pytest>=8.4.1",

--- a/backend/scheduler/core/programprovider/gpp/gppprogramprovider.py
+++ b/backend/scheduler/core/programprovider/gpp/gppprogramprovider.py
@@ -119,7 +119,7 @@ def parse_preimaging(sequence: List[dict]) -> bool:
     return preimaging
 
 # Return the basic name of a component, stripping off prefixes like GmosSouthFilter.
-def basic_name(full_name) -> str:
+def basic_name(full_name):
     return full_name.split('.')[-1] if full_name else None
 
 class GppProgramProvider(ProgramProvider):
@@ -1007,8 +1007,10 @@ class GppProgramProvider(ProgramProvider):
                           data: dict,
                           num: Tuple[Optional[int], int],
                           program_id: ProgramID,
+                          time_allocation: TimeAllocation,
                           split: bool = True,
-                          split_by_iterator: bool = False) -> Optional[Observation]:
+                          split_by_iterator: bool = False
+                          ) -> Optional[Observation]:
         """
         Parse GPP observation query dictionary into the minimodel observation
         """
@@ -1065,10 +1067,15 @@ class GppProgramProvider(ProgramProvider):
             acq_overhead = timedelta(seconds=data['execution']['digest']['value']['setup']['full']['seconds'])
 
             # Science band
-            band_value = data.get(GppProgramProvider._ObsKeys.BAND)
-            # Workaround if no band assigned
-            band = Band[band_value] if band_value is not None else Band['BAND2']
-            # print(f'\t\t band_value = {band_value}, band =  {band}')
+            band_value = basic_name(data.get(GppProgramProvider._ObsKeys.BAND))
+            # Workaround if no band assigned, use the highest Band with assigned time - this should come from the ODB
+            if band_value is None:
+                band = Band.BAND5
+                for time_alloc in time_allocation:
+                    band = time_alloc.band if time_alloc.band < band else band
+            else:
+                band = Band[band_value]
+            print(f'\t\t band_value = {band_value}, band =  {band}')
 
             # Calibration role
             cal_role_value = data.get(GppProgramProvider._ObsKeys.CALROLE)
@@ -1245,9 +1252,15 @@ class GppProgramProvider(ProgramProvider):
             program_id = ProgramID(
                 data[GppProgramProvider._ObsKeys.PROGRAM][GppProgramProvider._ObsKeys.INTERNAL_ID])
 
-        return self.parse_observation(data, num=(0, 0), program_id=program_id)
+        # Parse the time accounting allocation data - but this info isn't available in the observation only.
+        # ToDo: Bands must be assigned to all calibrations in the ODB before this method can be used
+        # time_act_alloc_data = data[GppProgramProvider._ProgramKeys.TIME_ACCOUNT_ALLOCATION]
+        # time_act_alloc = frozenset(self.parse_time_allocation(ta_data) for ta_data in time_act_alloc_data)
+
+        return self.parse_observation(data, num=(0, 0), program_id=program_id, time_allocation=None)
 
     def parse_group(self, data: dict, program_id: ProgramID, group_id: GroupID,
+                    time_allocation: TimeAllocation,
                     split: bool, split_by_iterator: bool, active: bool = True) -> Optional[Group]:
         """
         This method parses group information from GPP
@@ -1369,6 +1382,7 @@ class GppProgramProvider(ProgramProvider):
                 # Note, this seems to result in reverse order, so maybe not useful...
                 elem_parent_index += 1
                 obs = self.parse_observation(element['observation'], program_id=program_id, num=(0, 0),
+                                             time_allocation=time_allocation,
                                              split=split, split_by_iterator=split_by_iterator)
                 if obs is not None:
                     # Ignore Twilight and Day Cal observations for now
@@ -1380,6 +1394,7 @@ class GppProgramProvider(ProgramProvider):
             elif element['group']:
                 subgroup_id = GroupID(element['group']['id'])
                 subgroup = self.parse_group(element['group'], program_id, subgroup_id, split=split,
+                                            time_allocation=time_allocation,
                                             split_by_iterator=split_by_iterator, active=child_active)
                 if subgroup is not None:
                     children.append(subgroup)
@@ -1509,14 +1524,23 @@ class GppProgramProvider(ProgramProvider):
             # if GppProgramProvider._ProgramKeys.ID in data.keys() else ProgramID(internal_id)
         # print(f'parse_program: {program_id.id}')
 
+        # Parse the time accounting allocation data.
+        # time_act_alloc = None # Program.allocations
+        time_act_alloc_data = data[GppProgramProvider._ProgramKeys.TIME_ACCOUNT_ALLOCATION]
+        time_act_alloc = frozenset(self.parse_time_allocation(ta_data) for ta_data in time_act_alloc_data)
+        # print(f'time_act_alloc: {time_act_alloc}')
+
+        # Parse time previously used by previously observed observations not in the query
+        time_used = frozenset([self.parse_time_used(tc) for tc in data[GppProgramProvider._ProgramKeys.TIME_CHARGE]])
+
         # Initialize split variables - not used by GPP
         split = True
         split_by_iterator = False
 
         # Now we parse the groups.
         # root_group = GppProgramProvider._EMPTY_ROOT_GROUP
-        root_group = self.parse_group(data['root'], program_id, ROOT_GROUP_ID,
-                                      split=split, split_by_iterator=split_by_iterator)
+        root_group = self.parse_group(data['root'], program_id, ROOT_GROUP_ID, time_allocation=time_act_alloc,
+                                      split=split, split_by_iterator=split_by_iterator, )
         if root_group is None:
             logger.warning(f'Program {program_id} has empty root group. Skipping.')
             return None
@@ -1562,15 +1586,6 @@ class GppProgramProvider(ProgramProvider):
                       - Program.FUZZY_BOUNDARY)
         end_date = (datetime.fromisoformat(data['active']['end'] + 'T00:00:00')
                     + Program.FUZZY_BOUNDARY)
-
-        # Parse the time accounting allocation data.
-        # time_act_alloc = None # Program.allocations
-        time_act_alloc_data = data[GppProgramProvider._ProgramKeys.TIME_ACCOUNT_ALLOCATION]
-        time_act_alloc = frozenset(self.parse_time_allocation(ta_data) for ta_data in time_act_alloc_data)
-        # print(f'time_act_alloc: {time_act_alloc}')
-
-        # Parse time previously used by previously observed observations not in the query
-        time_used = frozenset([self.parse_time_used(tc) for tc in data[GppProgramProvider._ProgramKeys.TIME_CHARGE]])
 
         # ToOs
         too_type = TooType.NONE

--- a/backend/scheduler/scripts/run_sim.py
+++ b/backend/scheduler/scripts/run_sim.py
@@ -33,8 +33,9 @@ def main(*,
     asyncio.run(init_db_engine())
 
     # Parsed program file (this replaces the program picker from Schedule)
-    with open(programs_ids, 'r') as file:
-        programs_list = [line.strip() for line in file if line.strip()[0] != '#']
+    # with open(programs_ids, 'r') as file:
+    #     programs_list = [line.strip() for line in file if line.strip()[0] != '#']
+    programs_list = ['p-1260']
 
     # Create Parameters
     # params = SchedulerParameters(start=Time("2025-09-30 08:00:00", format='iso', scale='utc'),

--- a/changelog.d/GSCHED-1011.feature.md
+++ b/changelog.d/GSCHED-1011.feature.md
@@ -1,0 +1,1 @@
+Improve setting Band for GPP calibration

--- a/uv.lock
+++ b/uv.lock
@@ -2716,7 +2716,7 @@ wheels = [
 
 [[package]]
 name = "scheduler"
-version = "0.1.20"
+version = "0.1.21"
 source = { virtual = "backend" }
 dependencies = [
     { name = "aioboto3" },
@@ -2838,7 +2838,7 @@ docs = [
     { name = "mkdocs-mermaid2-plugin", specifier = ">=1.2.1" },
     { name = "mkdocstrings-python", specifier = ">=1.16.12" },
 ]
-gpp-dev = [{ name = "gpp-client", specifier = ">=26.7.3.dev6,==26.7.3.*,!=26.7.3" }]
+gpp-dev = [{ name = "gpp-client", specifier = ">=26.7.3.dev7,==26.7.3.*,!=26.7.3" }]
 gpp-prod = [{ name = "gpp-client", specifier = ">=26.7.1" }]
 
 [[package]]


### PR DESCRIPTION
Workaround for GPP calibrations that don't already have a band assigned.  It uses the highest band (lowest number) with allocated time.

## Scope

<!-- CI auto-detects this, but it helps reviewers to see at a glance. -->

- [ ] Backend (`backend/`)
- [ ] Frontend (`frontend/`)
- [ ] Docs (`docs/`)
- [ ] CI/Infra (`.github/`)


<!-- 
  REQUIRED: Add a changelog fragment file to this PR.
  
  Quickest way (auto-detects ticket from branch name):
    ./scripts/changelog-fragment "Your change description"
    ./scripts/changelog-fragment "Your change description" fix
    ./scripts/changelog-fragment "" misc

  Manual:
    echo "Description" > changelog.d/GSCHED-190.feature.md

  Types: feature, fix, breaking, deprecation, improvement, doc, misc
  CI will fail if no fragment is found (unless only CI/docs files changed).
-->


## Jira

<!-- JIRA:START -->
<!-- Auto-linked from branch name (e.g. GSCHED-190/description) by the PR Jira Link workflow. -->
<!-- JIRA:END -->

## Checklist

- [ ] Changelog fragment added to `changelog.d/`
- [ ] Commit messages follow conventional commits (`feat(backend):`, `fix(frontend):`, etc.)
- [ ] No breaking changes (or `breaking` fragment added)
